### PR TITLE
puppet 3.7 complaines about 'Error: Failed to apply catalog: Parameter c...

### DIFF
--- a/manifests/module.pp
+++ b/manifests/module.pp
@@ -49,7 +49,7 @@ define selinux::module(
   exec { "${name}-checkloaded":
     refreshonly   => false,
     creates       => "/etc/selinux/${::selinux_config_policy}/modules/active/modules/${name}.pp",
-    command       => true,
+    command       => 'true',
     notify        => Exec["${name}-buildmod"],
   }
 


### PR DESCRIPTION
puppet 3.7 complaines about 'Error: Failed to apply catalog: Parameter command failed on Exec[modulename-checkloaded]: Command must be a String, got value of class TrueClass'
