### PR TITLE
Add missing quotes to exec statement

### DIFF
--- a/manifests/module.pp
+++ b/manifests/module.pp
@@ -73,7 +73,7 @@ define selinux::module(
     present: {
       if $use_makefile {
         exec { "${name}-buildmod":
-          command => true,
+          command => "true",
         }
         exec { "${name}-buildpp":
           command => "make -f ${makefile} ${name}.pp",


### PR DESCRIPTION
The command parameter on an exec resource needs to be a string.
