### PR TITLE
Fix for dependency cycle in module.pp

### DIFF
--- a/manifests/module.pp
+++ b/manifests/module.pp
@@ -37,7 +37,7 @@ define selinux::module(
   $syncversion  = true,
 ) {
 
-  require selinux
+  include ::selinux
 
   validate_re($ensure, [ '^present$', '^absent$' ], '$ensure must be "present" or "absent"')
   if $ensure == 'present' and $source == undef and $content == undef {


### PR DESCRIPTION
When trying to deploy custom policy modules defined in hiera, the module.pp introduces a
dependency cycle. See the error below:

I have defined one custom policy in hiera (selinux_modules) and called "include ::selinux"

Error: Could not apply complete catalog: Found 1 dependency cycle:
(Exec[/usr/share/selinux/local_test-module.pp] =>
Selinux::Module[test-module] => Class[Selinux] =>
Selinux::Module[test-module] =>
Exec[/usr/share/selinux/local_test-module.pp])

To fix this, I have changed "require ::selinux" to "include ::selinux"