### PR TITLE
Fixes Issue-105 - fcontext detection with square brackets

### DIFF
--- a/manifests/fcontext.pp
+++ b/manifests/fcontext.pp
@@ -70,7 +70,7 @@ define selinux::fcontext (
   $destination         = undef,
   $context             = undef,
   $filetype            = false,
-  $filemode            = undef,
+  $filemode            = 'a',
   $equals              = false,
   $restorecond         = true,
   $restorecond_path    = undef,
@@ -111,15 +111,11 @@ define selinux::fcontext (
   if $equals {
     $resource_name = "add_${destination}_${pathname}"
     $command       = "semanage fcontext -a -e \"${destination}\" \"${pathname}\""
-    $unless        = "semanage fcontext -l | grep -E \"^${pathname} = ${destination}$\""
-  } elsif $filetype {
+    $unless        = "semanage fcontext -E | grep -F \"fcontext -a -e ${pathname} ${destination}$\""
+  } else {
     $resource_name = "add_${context}_${pathname}_type_${filemode}"
     $command       = "semanage fcontext -a -f ${filemode} -t ${context} \"${pathname}\""
-    $unless        = "semanage fcontext -l | grep \"^${pathname}[[:space:]].*:${context}:\""
-  } else {
-    $resource_name = "add_${context}_${pathname}"
-    $command       = "semanage fcontext -a -t ${context} \"${pathname}\""
-    $unless        = "semanage fcontext -l | grep \"^${pathname}[[:space:]].*:${context}:\""
+    $unless        = "semanage fcontext -E | grep -F \"fcontext -a -f $filemode -t ${context} \'${pathname}\'\""
   }
 
   exec { $resource_name:


### PR DESCRIPTION
This fixes the issue of detecting existing contexts with square brackets using `semanage fcontext -E`, which produces much more "parsable" output. It also somewhat simplifies the "$filemode" stuff since "a" is the default. It will also properly detect if an fcontext exists with the wrong filemode and create it with the correct filemode. However, since we are not "purging" (which would probably be super dangerous), it won't *remove* any rules that are incorrect.