### PR TITLE
Fixing operatingsystem for Amazon Linux

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -37,6 +37,17 @@ class selinux::params {
             }
           }
         }
+       'Amazon': {
+        $sx_fs_mount = '/selinux'
+          case $os_maj_release {
+            '4': {
+              $package_name = 'policycoreutils-python'
+            }
+            default: {
+              fail("${::operatingsystem}-${::os_maj_release} is not supported")
+            }
+          }
+        }
         default: {
           case $os_maj_release {
             '7': {


### PR DESCRIPTION
We had an issue with Amazon Linux servers. This fix is for avoiding the legend 'Operating system is not supported'