### PR TITLE
params.pp needs to know about Fedora 25

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -32,7 +32,7 @@ class selinux::params {
             '21','22','23' : {
               $package_name = 'policycoreutils-devel'
             }
-            '24' : {
+            '24', '25' : {
               $package_name = 'selinux-policy-devel'
             }
             default: {


### PR DESCRIPTION
Fedora 25 is (well, will be, once it's officially released) basically the same as Fedora 24, as far as puppet-selinux is concerned, so here's a quick update to keep it from erroring out. :smiley: