### PR TITLE
Fixes #133 Use semange -f 'all files' on RHEL6

### DIFF
--- a/manifests/fcontext.pp
+++ b/manifests/fcontext.pp
@@ -113,8 +113,23 @@ define selinux::fcontext (
       fail('"filemode" must be one of: a,f,d,c,b,s,l,p - see "man semanage-fcontext"')
     }
     $resource_name = "add_${context}_${pathname}_type_${filemode}"
-    $command       = shellquote('semanage', 'fcontext','-a', '-f', $filemode, '-t', $context, $pathname)
-    $unless        = sprintf('semanage fcontext -E | grep -Fx %s', shellquote("fcontext -a -f ${filemode} -t ${context} '${pathname}'"))
+    if $::osfamily == 'RedHat' and $::operatingsystemmajrelease == '6' {
+      case $filemode {
+        'a': {
+          $_filemode = 'all files'
+          $_quotedfilemode = '\'all files\''
+          }
+        default: {
+          $_filemode = $filemode
+          $_quotedfilemode = $_filemode
+        }
+      }
+    } else {
+      $_filemode = $filemode
+      $_quotedfilemode = $_filemode
+    }
+    $command       = shellquote('semanage', 'fcontext','-a', '-f', $_filemode, '-t', $context, $pathname)
+    $unless        = sprintf('semanage fcontext -E | grep -Fx %s', shellquote("fcontext -a -f ${_quotedfilemode} -t ${context} '${pathname}'"))
   }
 
   Exec {

--- a/spec/defines/selinux_fcontext_spec.rb
+++ b/spec/defines/selinux_fcontext_spec.rb
@@ -88,7 +88,11 @@ describe 'selinux::fcontext' do
             context: 'user_home_dir_t'
           }
         end
-        it { is_expected.to contain_exec('add_user_home_dir_t_/tmp/file1_type_a').with(command: 'semanage fcontext -a -f a -t user_home_dir_t /tmp/file1') }
+        if (facts[:osfamily] == 'RedHat') && (facts[:operatingsystemmajrelease] == '6')
+          it { is_expected.to contain_exec('add_user_home_dir_t_/tmp/file1_type_a').with(command: 'semanage fcontext -a -f "all files" -t user_home_dir_t /tmp/file1') }
+        else
+          it { is_expected.to contain_exec('add_user_home_dir_t_/tmp/file1_type_a').with(command: 'semanage fcontext -a -f a -t user_home_dir_t /tmp/file1') }
+        end
         it { is_expected.to contain_exec('restorecond add_user_home_dir_t_/tmp/file1_type_a').with(command: 'restorecon /tmp/file1') }
       end
 
@@ -99,7 +103,11 @@ describe 'selinux::fcontext' do
             context: 'user_home_dir_t'
           }
         end
-        it { is_expected.to contain_exec('add_user_home_dir_t_/tmp/file1_type_a').with(command: 'semanage fcontext -a -f a -t user_home_dir_t /tmp/file1') }
+        if (facts[:osfamily] == 'RedHat') && (facts[:operatingsystemmajrelease] == '6')
+          it { is_expected.to contain_exec('add_user_home_dir_t_/tmp/file1_type_a').with(command: 'semanage fcontext -a -f "all files" -t user_home_dir_t /tmp/file1') }
+        else
+          it { is_expected.to contain_exec('add_user_home_dir_t_/tmp/file1_type_a').with(command: 'semanage fcontext -a -f a -t user_home_dir_t /tmp/file1') }
+        end
         it { is_expected.to contain_exec('restorecond add_user_home_dir_t_/tmp/file1_type_a').with(command: 'restorecon /tmp/file1') }
       end
 
@@ -121,7 +129,11 @@ describe 'selinux::fcontext' do
             restorecond_path: '/tmp/file1/different'
           }
         end
-        it { is_expected.to contain_exec('add_user_home_dir_t_/tmp/file1_type_a').with(command: 'semanage fcontext -a -f a -t user_home_dir_t /tmp/file1') }
+        if (facts[:osfamily] == 'RedHat') && (facts[:operatingsystemmajrelease] == '6')
+          it { is_expected.to contain_exec('add_user_home_dir_t_/tmp/file1_type_a').with(command: 'semanage fcontext -a -f "all files" -t user_home_dir_t /tmp/file1') }
+        else
+          it { is_expected.to contain_exec('add_user_home_dir_t_/tmp/file1_type_a').with(command: 'semanage fcontext -a -f a -t user_home_dir_t /tmp/file1') }
+        end
         it { is_expected.to contain_exec('restorecond add_user_home_dir_t_/tmp/file1_type_a').with(command: 'restorecon /tmp/file1/different') }
       end
       context 'with restorecon recurse specific path' do
@@ -133,7 +145,13 @@ describe 'selinux::fcontext' do
             restorecond_recurse: true
           }
         end
-        it { is_expected.to contain_exec('add_user_home_dir_t_/tmp/file1_type_a').with(command: 'semanage fcontext -a -f a -t user_home_dir_t /tmp/file1') }
+        if (facts[:osfamily] == 'RedHat') && (facts[:operatingsystemmajrelease] == '6')
+          it { is_expected.to contain_exec('add_user_home_dir_t_/tmp/file1_type_a').with(command: 'semanage fcontext -a -f "all files" -t user_home_dir_t /tmp/file1') }
+          it { is_expected.to contain_exec('add_user_home_dir_t_/tmp/file1_type_a').with(unless: "semanage fcontext -E | grep -Fx \"fcontext -a -f 'all files' -t user_home_dir_t '/tmp/file1'\"") }
+        else
+          it { is_expected.to contain_exec('add_user_home_dir_t_/tmp/file1_type_a').with(command: 'semanage fcontext -a -f a -t user_home_dir_t /tmp/file1') }
+          it { is_expected.to contain_exec('add_user_home_dir_t_/tmp/file1_type_a').with(unless: "semanage fcontext -E | grep -Fx \"fcontext -a -f a -t user_home_dir_t '/tmp/file1'\"") }
+        end
         it { is_expected.to contain_exec('restorecond add_user_home_dir_t_/tmp/file1_type_a').with(command: 'restorecon -R /tmp/file1/different') }
       end
       context 'with restorecon path with quotation' do
@@ -143,7 +161,11 @@ describe 'selinux::fcontext' do
             context: 'user_home_dir_t'
           }
         end
-        it { is_expected.to contain_exec('add_user_home_dir_t_/tmp/"$HOME"/"$PATH"/[^ \'\\\#\`]+(?:.*)_type_a').with(command: 'semanage fcontext -a -f a -t user_home_dir_t "/tmp/\\"\\$HOME\\"/\\"\\$PATH\\"/[^ \'\\\\\\\\#\\\\\`]+(?:.*)"') }
+        if (facts[:osfamily] == 'RedHat') && (facts[:operatingsystemmajrelease] == '6')
+          it { is_expected.to contain_exec('add_user_home_dir_t_/tmp/"$HOME"/"$PATH"/[^ \'\\\#\`]+(?:.*)_type_a').with(command: 'semanage fcontext -a -f "all files" -t user_home_dir_t "/tmp/\\"\\$HOME\\"/\\"\\$PATH\\"/[^ \'\\\\\\\\#\\\\\`]+(?:.*)"') }
+        else
+          it { is_expected.to contain_exec('add_user_home_dir_t_/tmp/"$HOME"/"$PATH"/[^ \'\\\#\`]+(?:.*)_type_a').with(command: 'semanage fcontext -a -f a -t user_home_dir_t "/tmp/\\"\\$HOME\\"/\\"\\$PATH\\"/[^ \'\\\\\\\\#\\\\\`]+(?:.*)"') }
+        end
         it { is_expected.to contain_exec('restorecond add_user_home_dir_t_/tmp/"$HOME"/"$PATH"/[^ \'\\\#\`]+(?:.*)_type_a').with(command: 'restorecon "/tmp/\\"\\$HOME\\"/\\"\\$PATH\\"/[^ \'\\\\\\\\#\\\\\`]+(?:.*)"') }
       end
     end


### PR DESCRIPTION
<!--
Thank you for contributing to this project!
- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
-->

The command

```bash
semanage fcontext -a -f a -t httpd_tmp_t /usr/share/nginx
```

fails on RHEL6 machines. This changes it to

```bash
semanage fcontext -a -f 'all files' -t httpd_tmp_t /usr/share/nginx
```

* https://github.com/voxpupuli/puppet-selinux/issues/133