### PR TITLE
Default module prefix now ''

### DIFF
--- a/manifests/module.pp
+++ b/manifests/module.pp
@@ -13,7 +13,7 @@
 #   - $sx_mod_dir (absolute_path) - sets the operating state for SELinux.
 #   - $source: the source file (either a puppet URI or local file) of the SELinux .te module
 #   - $makefile: the makefile file path
-#   - $prefix: the prefix to add to the loaded module. Defaults to 'local_'.
+#   - $prefix: the prefix to add to the loaded module. Defaults to ''.
 #
 # Actions:
 #  Compiles a module using make and installs it
@@ -32,7 +32,7 @@ define selinux::module(
   $content      = undef,
   $ensure       = 'present',
   $makefile     = '/usr/share/selinux/devel/Makefile',
-  $prefix       = 'local_',
+  $prefix       = '',
   $sx_mod_dir   = '/usr/share/selinux',
   $syncversion  = true,
 ) {

--- a/spec/defines/selinux_module_spec.rb
+++ b/spec/defines/selinux_module_spec.rb
@@ -17,6 +17,21 @@ describe 'selinux::module' do
         end
 
         it do
+          is_expected.to contain_file('/usr/share/selinux/mymodule.te').that_notifies('Exec[/usr/share/selinux/mymodule.pp]')
+          is_expected.to contain_exec('/usr/share/selinux/mymodule.pp').with(command: 'make -f /usr/share/selinux/devel/Makefile mymodule.pp')
+          is_expected.to contain_selmodule('mymodule').with_ensure('present')
+        end
+      end
+
+      context 'present case and prefix set' do
+        let(:params) do
+          {
+            source: 'puppet:///modules/mymodule/selinux/mymodule.te',
+            prefix: 'local_'
+          }
+        end
+
+        it do
           is_expected.to contain_file('/usr/share/selinux/local_mymodule.te').that_notifies('Exec[/usr/share/selinux/local_mymodule.pp]')
           is_expected.to contain_exec('/usr/share/selinux/local_mymodule.pp').with(command: 'make -f /usr/share/selinux/devel/Makefile local_mymodule.pp')
           is_expected.to contain_selmodule('mymodule').with_ensure('present')


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.

-->

With RHEL7.3 the default module prefix causes problems
in particular the following happens

with

```puppet
selinux::module { 'openshift-cvmfs':
  ensure => present,
  source => 'puppet:///modules/hg_paas/openshift-cvmfs.te',
}

```

```
Compiling targeted local_openshift-cvmfs module
/usr/bin/checkmodule:  loading policy configuration from
tmp/local_openshift-cvmfs.tmp
/usr/bin/checkmodule:  Module name openshift-cvmfs is different than the
output base filename local_openshift-cvmfs
make: *** [tmp/local_openshift-cvmfs.mod] Error 1
```

As far as I can ascertain the prefix only influences the file name
and actual module name comes from what's inside the policy file.

Anyone testing this may well runinto another selinux bug that
is not a problem of this module.

* [CERN ticket reference](https://its.cern.ch/jira/browse/AI-4745)
* [Change in checkmodule](https://github.com/SELinuxProject/selinux/commit/c6acfae4bc22586ad1dc259b0aad57fa6c5b43ef#diff-9a0edd4c660062ff41e43d787595141d)
* [puppet problem](https://bugzilla.redhat.com/show_bug.cgi?id=1391886)
* [selinux bug](https://bugzilla.redhat.com/show_bug.cgi?id=1395222)