### PR TITLE
Add acceptance tests

### DIFF
--- a/spec/acceptance/class_spec.rb
+++ b/spec/acceptance/class_spec.rb
@@ -1,0 +1,80 @@
+require 'spec_helper_acceptance'
+
+describe 'selinux class' do
+  let(:pp) do
+    <<-EOS
+      class { 'selinux': mode => 'enforcing' }
+
+      # with puppet4 I would use a HERE DOC to make this pretty,
+      # but with puppet3 it's not possible.
+      selinux::module { 'puppet_selinux_test_policy':
+        content => "policy_module(puppet_selinux_test_policy, 1.0.0)\ngen_tunable(puppet_selinux_test_policy_bool, false)\ntype puppet_selinux_test_policy_t;\ntype puppet_selinux_test_policy_exec_t;\ninit_daemon_domain(puppet_selinux_test_policy_t, puppet_selinux_test_policy_exec_t)\ntype puppet_selinux_test_policy_port_t;\ncorenet_port(puppet_selinux_test_policy_port_t)\n",
+        prefix => '',
+        syncversion => undef,
+      } ->
+
+      file { '/tmp/test_selinux_fcontext':
+        content => 'TEST',
+        seltype => 'puppet_selinux_test_policy_exec_t',
+      } ->
+
+      selinux::boolean { 'puppet_selinux_test_policy_bool': } ->
+
+      selinux::permissive { 'puppet_selinux_test_policy_t': context => 'puppet_selinux_test_policy_t', } ->
+
+      selinux::port { 'puppet_selinux_test_policy_port_t/tcp':
+        context => 'puppet_selinux_test_policy_port_t',
+        port => '55555',
+        protocol => 'tcp',
+      }
+    EOS
+  end
+
+  it_behaves_like 'a idempotent resource'
+
+  describe package('selinux-policy-targeted') do
+    it { is_expected.to be_installed }
+  end
+
+  describe file('/etc/selinux/config') do
+    its(:content) { is_expected.to match(%r{^SELINUX=enforcing$}) }
+  end
+
+  describe command('getenforce') do
+    its(:stdout) { is_expected.to match(%r{^Enforcing$}) }
+  end
+
+  context 'the test module source should exist and the module should be loaded' do
+    describe file('/usr/share/selinux/puppet_selinux_test_policy.te') do
+      it { is_expected.to be_file }
+    end
+
+    describe command('semodule -l | grep puppet_selinux_test_policy') do
+      its(:stdout) { is_expected.to match(%r{puppet_selinux_test_policy}) }
+    end
+  end
+
+  context 'the test file should have the specified file context' do
+    describe file('/tmp/test_selinux_fcontext') do
+      its(:selinux_label) { is_expected.to match(%r{^.*:puppet_selinux_test_policy_exec_t:s0$}) }
+    end
+  end
+
+  context 'test boolean is available and activated' do
+    describe command('getsebool puppet_selinux_test_policy_bool') do
+      its(:stdout) { is_expected.to match(%r{puppet_selinux_test_policy_bool --> on}) }
+    end
+  end
+
+  context 'test domain is permissive' do
+    describe command('semanage permissive -l') do
+      its(:stdout) { is_expected.to match(%r{^puppet_selinux_test_policy_t$}) }
+    end
+  end
+
+  context 'port 55555 should have type puppet_selinux_test_policy_port_t' do
+    describe command('semanage port -l | grep puppet_selinux_test_policy_port_t') do
+      its(:stdout) { is_expected.to match(%r{puppet_selinux_test_policy_port_t.*55555$}) }
+    end
+  end
+end

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -1,0 +1,34 @@
+require 'beaker-rspec/spec_helper'
+require 'beaker-rspec/helpers/serverspec'
+require 'beaker/puppet_install_helper'
+
+run_puppet_install_helper unless ENV['BEAKER_provision'] == 'no'
+
+RSpec.configure do |c|
+  # Project root
+  proj_root = File.expand_path(File.join(File.dirname(__FILE__), '..'))
+
+  # Readable test descriptions
+  c.formatter = :documentation
+
+  # Configure all nodes in nodeset
+  c.before :suite do
+    # Install module and dependencies
+    puppet_module_install(source: proj_root, module_name: 'selinux')
+    hosts.each do |host|
+      on host, puppet('module', 'install', 'puppetlabs-stdlib'), acceptable_exit_codes: [0, 1]
+      on(host, 'sed -i "s/SELINUX=.*/SELINUX=permissive/" /etc/selinux/config')
+      host.reboot
+    end
+  end
+end
+
+shared_examples 'a idempotent resource' do
+  it 'applies with no errors' do
+    apply_manifest(pp, catch_failures: true)
+  end
+
+  it 'applies a second time without changes' do
+    apply_manifest(pp, catch_changes: true)
+  end
+end


### PR DESCRIPTION
This PR adds a simple acceptance test scenario.

It will:

* enable selinux
* set it to enforcing
* load a custom policy with a custom domain, boolean and file and port
contexts
* enable a custom boolean
* label a port with a custom context
* set a custom context on a file and 
* it will set the custom domain into permissive mode

Run `PUPPET_INSTALL_TYPE=agent bundle exec rake beaker:centos-72-x64` to
test with CentOS 7.

Run `PUPPET_INSTALL_TYPE=agent bundle exec rake beaker:centos-66-x64` to
test with CentOS 6.

There is a known problem with CentOS 7 and the selmodule type. See 
PUP-6908, PUP-5649