### PR TITLE
Create /.autorelabel when switching from disabled

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -59,6 +59,18 @@ class selinux::config (
       }
     }
 
+    # a complete relabeling is required when switching from disabled to
+    # permissive or enforcing. Ensure the autorelabel trigger file is created.
+    if $mode in ['enforcing','permissive'] and
+      !$::selinux_enabled {
+      file { '/.autorelabel':
+        ensure  => 'file',
+        owner   => 'root',
+        group   => 'root',
+        content => "# created by puppet for disabled to ${mode} switch\n",
+      }
+    }
+
     exec { "change-selinux-status-to-${mode}":
       command => "setenforce ${sestatus}",
       unless  => "getenforce | grep -Eqi '${mode}|disabled'",

--- a/spec/classes/selinux_config_mode_spec.rb
+++ b/spec/classes/selinux_config_mode_spec.rb
@@ -24,6 +24,7 @@ describe 'selinux' do
           it { is_expected.not_to contain_exec('change-selinux-status-to-enforcing') }
           it { is_expected.not_to contain_exec('change-selinux-status-to-permissive') }
           it { is_expected.not_to contain_exec('change-selinux-status-to-disabled') }
+          it { is_expected.not_to contain_file('/.autorelabel') }
         end
 
         context 'enforcing' do
@@ -32,6 +33,7 @@ describe 'selinux' do
           it { is_expected.to contain_file('/usr/share/selinux').with(ensure: 'directory') }
           it { is_expected.to contain_file_line('set-selinux-config-to-enforcing').with(line: 'SELINUX=enforcing') }
           it { is_expected.to contain_exec('change-selinux-status-to-enforcing').with(command: 'setenforce 1') }
+          it { is_expected.not_to contain_file('/.autorelabel') }
         end
 
         context 'permissive' do
@@ -39,6 +41,7 @@ describe 'selinux' do
           it { is_expected.to contain_file('/usr/share/selinux').with(ensure: 'directory') }
           it { is_expected.to contain_file_line('set-selinux-config-to-permissive').with(line: 'SELINUX=permissive') }
           it { is_expected.to contain_exec('change-selinux-status-to-permissive').with(command: 'setenforce 0') }
+          it { is_expected.not_to contain_file('/.autorelabel') }
         end
 
         context 'disabled' do
@@ -46,6 +49,23 @@ describe 'selinux' do
           it { is_expected.to contain_file('/usr/share/selinux').with(ensure: 'directory') }
           it { is_expected.to contain_file_line('set-selinux-config-to-disabled').with(line: 'SELINUX=disabled') }
           it { is_expected.to contain_exec('change-selinux-status-to-disabled').with(command: 'setenforce 0') }
+          it { is_expected.not_to contain_file('/.autorelabel') }
+        end
+
+        context 'disabled to permissive creates autorelabel trigger file' do
+          let(:facts) do
+            facts.merge(selinux_enabled: false)
+          end
+          let(:params) { { mode: 'permissive' } }
+          it { is_expected.to contain_file('/.autorelabel').with(ensure: 'file') }
+        end
+
+        context 'disabled to enforcing creates autorelabel trigger file' do
+          let(:facts) do
+            facts.merge(selinux_enabled: false)
+          end
+          let(:params) { { mode: 'enforcing' } }
+          it { is_expected.to contain_file('/.autorelabel').with(ensure: 'file') }
         end
       end
     end

--- a/spec/default_module_facts.yml
+++ b/spec/default_module_facts.yml
@@ -4,6 +4,7 @@ operatingsystem: RedHat
 operatingsystemmajrelease: '7'
 selinux_config_mode: enforcing
 selinux_current_mode: enforcing
+selinux_enabled: true
 selinux_config_policy: targeted
 # concat facts
 id: 0


### PR DESCRIPTION
A complete relabeling is required when switching from disabeld to
permissive or enforcing mode, because selinux file attributes
are not written in disabled mode this leaving the files regarding
selinux in an incosistent state.

This resolves #149