### PR TITLE
Fix usage of non-existent $::selinux_enabled fact

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -62,7 +62,7 @@ class selinux::config (
     # a complete relabeling is required when switching from disabled to
     # permissive or enforcing. Ensure the autorelabel trigger file is created.
     if $mode in ['enforcing','permissive'] and
-      !$::selinux_enabled {
+      !$::selinux {
       file { '/.autorelabel':
         ensure  => 'file',
         owner   => 'root',

--- a/spec/classes/selinux_config_mode_spec.rb
+++ b/spec/classes/selinux_config_mode_spec.rb
@@ -4,7 +4,13 @@ describe 'selinux' do
   on_supported_os.each do |os, facts|
     context "on #{os}" do
       let(:facts) do
-        facts
+        facts.merge(
+          selinux_enabled: true,
+          selinux: true,
+          selinux_config_mode: 'enforcing',
+          selinux_config_policy: 'targeted',
+          selinux_current_mode: 'enforcing',
+        )
       end
 
       context 'config' do
@@ -54,7 +60,14 @@ describe 'selinux' do
 
         context 'disabled to permissive creates autorelabel trigger file' do
           let(:facts) do
-            facts.merge(selinux_enabled: false)
+            hash = facts.merge(
+              selinux_enabled: false,
+              selinux: false,
+            )
+            hash.delete(:selinux_config_mode)
+            hash.delete(:selinux_current_mode)
+            hash.delete(:selinux_config_policy)
+            hash
           end
           let(:params) { { mode: 'permissive' } }
           it { is_expected.to contain_file('/.autorelabel').with(ensure: 'file') }
@@ -62,7 +75,13 @@ describe 'selinux' do
 
         context 'disabled to enforcing creates autorelabel trigger file' do
           let(:facts) do
-            facts.merge(selinux_enabled: false)
+            hash = facts.merge(
+              selinux_enabled: false,
+            )
+            hash.delete(:selinux_config_mode)
+            hash.delete(:selinux_current_mode)
+            hash.delete(:selinux_config_policy)
+            hash
           end
           let(:params) { { mode: 'enforcing' } }
           it { is_expected.to contain_file('/.autorelabel').with(ensure: 'file') }

--- a/spec/classes/selinux_config_mode_spec.rb
+++ b/spec/classes/selinux_config_mode_spec.rb
@@ -5,11 +5,10 @@ describe 'selinux' do
     context "on #{os}" do
       let(:facts) do
         facts.merge(
-          selinux_enabled: true,
           selinux: true,
           selinux_config_mode: 'enforcing',
           selinux_config_policy: 'targeted',
-          selinux_current_mode: 'enforcing',
+          selinux_current_mode: 'enforcing'
         )
       end
 
@@ -61,8 +60,7 @@ describe 'selinux' do
         context 'disabled to permissive creates autorelabel trigger file' do
           let(:facts) do
             hash = facts.merge(
-              selinux_enabled: false,
-              selinux: false,
+              selinux: false
             )
             hash.delete(:selinux_config_mode)
             hash.delete(:selinux_current_mode)
@@ -76,7 +74,7 @@ describe 'selinux' do
         context 'disabled to enforcing creates autorelabel trigger file' do
           let(:facts) do
             hash = facts.merge(
-              selinux_enabled: false,
+              selinux: false
             )
             hash.delete(:selinux_config_mode)
             hash.delete(:selinux_current_mode)

--- a/spec/default_module_facts.yml
+++ b/spec/default_module_facts.yml
@@ -2,10 +2,6 @@
 osfamily: RedHat
 operatingsystem: RedHat
 operatingsystemmajrelease: '7'
-selinux_config_mode: enforcing
-selinux_current_mode: enforcing
-selinux_enabled: true
-selinux_config_policy: targeted
 # concat facts
 id: 0
 path: /tmp


### PR DESCRIPTION
The fact is in fact called $::selinux not $::selinux_enabled.
    
It was not caught by the spec test because it was specified in
default_module_facts.yaml.
    
 And there is only a WIP accetpance test for disabled to enforcing
switch which will check this too in future.

The existing acceptance tests for centos-72-x64 and 
centos-66-x64 discovered no problems with this PR.
