### PR TITLE
Release 0.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## 2016-12-28 Release 0.7.1
+
+- selinux::module syncversion parameter now defaults to undef
+  to workaround puppet selmodule syncversion bug on CentOS >= 7.3 ([PR #158](https://github.com/voxpupuli/puppet-selinux/pull/158))
+- Bugfix for wrong named fact used in selinux::config ([PR #159](https://github.com/voxpupuli/puppet-selinux/pull/159))
+
 ## 2016-12-14 Release 0.7.0
 
 - Remove custom fact selinux_custom_policy (not used anymore)

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "puppet-selinux",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "author": "Vox Pupuli",
   "summary": "This class manages SELinux on RHEL based systems",
   "license": "Apache-2.0",


### PR DESCRIPTION
Log diff between 0.7.0 and this PR:

a7f1de8 Release 0.7.1
c607c09 Fix usage of non-existent $::selinux_enabled fact
7e0514f Enable spec tests to delete selinux facts
53c8946 Update selinux::module inline docs to puppet-strings format
140389f Default to undef for syncversion parameter in selinux::module
25c63c6 Remove mentions of Ruby requirements in README
