### PR TITLE
Don't add selboolean resources while selinux is disabled

### DIFF
--- a/manifests/boolean.pp
+++ b/manifests/boolean.pp
@@ -1,30 +1,21 @@
-# Definition: selinux::boolean
+# Defined type: selinux::boolean
 #
-# Description
-#  This class will set the state of an SELinux boolean.
-#  All pending values are written to the policy file on disk, so they will be persistant across reboots.
-#  Ensure that the manifest notifies a related service as a restart for that service may be required.
+# This class will set the state of an SELinux boolean.
+# All pending values are written to the policy file on disk, so they will be persistant across reboots.
+# Ensure that the manifest notifies a related service as a restart for that service may be required.
 #
-# Class created by GreenOgre<aggibson@cogeco.ca>
-#  Adds to puppet-selinux by jfryman
-#   https://github.com/jfryman/puppet-selinux
+# @example activate boolean
+#   selinux::boolean{ 'named_write_master_zones':
+#      ensure     => 'on',
+#   }
 #
-# Parameters:
-#   - $ensure: (on|off) - Sets the current state of a particular SELinux boolean
-#   - $persistent: (true|false) - Should a particular SELinux boolean persist across reboots
+# @example disable boolean
+#   selinux::boolean{ 'named_write_master_zones':
+#      ensure     => 'off',
+#   }
 #
-# Actions:
-#  Wraps selboolean to set states
-#
-# Requires:
-#  - SELinux
-#
-# Sample Usage:
-#
-#  selinux::boolean{ 'named_write_master_zones':
-#     ensure     => "on",
-#     persistent => true,
-#  }
+# @param ensure Sets the current state of a particular SELinux boolean. Valid values: on, off
+# @param persistent Should a particular SELinux boolean persist across reboots
 #
 define selinux::boolean (
   $ensure     = 'on',
@@ -48,8 +39,12 @@ define selinux::boolean (
     default                    => undef,
   }
 
-  selboolean { $name:
-    value      => $value,
-    persistent => $persistent,
+  # seboolean calls getsebool and setsebool 
+  # they only work when current mode is not disabled.
+  if $::selinux {
+    selboolean { $name:
+      value      => $value,
+      persistent => $persistent,
+    }
   }
 }

--- a/spec/defines/selinux_boolean_spec.rb
+++ b/spec/defines/selinux_boolean_spec.rb
@@ -5,7 +5,12 @@ describe 'selinux::boolean' do
   on_supported_os.each do |os, facts|
     context "on #{os}" do
       let(:facts) do
-        facts
+        facts.merge(
+          selinux: true,
+          selinux_config_mode: 'enforcing',
+          selinux_config_policy: 'targeted',
+          selinux_current_mode: 'enforcing'
+        )
       end
 
       ['on', true, 'present'].each do |value|
@@ -36,6 +41,44 @@ describe 'selinux::boolean' do
               'value'      => 'off',
               'persistent' => true
             )
+          end
+        end
+      end
+    end
+
+    # getsebool/setsebool required by selboolean type
+    # don't work while selinux is in disabled mode.
+    context "on #{os} with selinux disabled" do
+      let(:facts) do
+        hash = facts.merge(selinux: false)
+        hash.delete(:selinux_config_mode)
+        hash.delete(:selinux_config_policy)
+        hash.delete(:selinux_current_mode)
+        hash
+      end
+
+      ['on', true, 'present'].each do |value|
+        context value do
+          let(:params) do
+            {
+              ensure: value
+            }
+          end
+          it do
+            is_expected.not_to contain_selboolean('mybool')
+          end
+        end
+      end
+
+      ['off', false, 'absent'].each do |value|
+        context value do
+          let(:params) do
+            {
+              ensure: value
+            }
+          end
+          it do
+            is_expected.not_to contain_selboolean('mybool')
           end
         end
       end


### PR DESCRIPTION
The selboolean type calls getsebool and setsebool to manage
the boolean. They only work if selinux is enabled either in
permissive or enforcing mode.

This change checks if selinux is enabled and only managages
the selboolean resource if selinux is enabled.