### PR TITLE
Add Fedora 24 and 25 acceptance test nodesets

### DIFF
--- a/spec/acceptance/nodesets/fedora-24-x64.yml
+++ b/spec/acceptance/nodesets/fedora-24-x64.yml
@@ -1,0 +1,13 @@
+---
+# module custome nodeset
+HOSTS:
+  fedora-24-x64:
+    roles:
+      - master
+    platform: fedora-24-x86_64
+    box: fedora/24-cloud-base
+    hypervisor: vagrant
+CONFIG:
+  type: aio
+...
+# vim: syntax=yaml

--- a/spec/acceptance/nodesets/fedora-25-x64.yml
+++ b/spec/acceptance/nodesets/fedora-25-x64.yml
@@ -1,0 +1,17 @@
+---
+# module custom nodeset
+#
+# platform is fedora 24 because there is no
+# puppet-agent for fedora 25 by 2016-12-30
+#
+HOSTS:
+  fedora-25-x64:
+    roles:
+      - master
+    platform: fedora-24-x86_64
+    box: fedora/25-cloud-base
+    hypervisor: vagrant
+CONFIG:
+  type: aio
+...
+# vim: syntax=yaml


### PR DESCRIPTION
Succsessfully run the acceptance test class_spec on both platforms.

F24:

```
PUPPET_INSTALL_TYPE=agent BEAKER_destroy=no  BEAKER_set=fedora-24-x64 bundle exec rspec spec/acceptance/class_spec.rb
...
selinux class
  behaves like a idempotent resource
localhost $ scp /tmp/beaker20161230-16728-ucn6v5 fedora-24-x64:/tmp/apply_manifest.pp.H50Be2 {:ignore => }
    applies with no errors
localhost $ scp /tmp/beaker20161230-16728-1jfmp5c fedora-24-x64:/tmp/apply_manifest.pp.VL9jL1 {:ignore => }
    applies a second time without changes
  Package "selinux-policy-targeted"
    should be installed
  File "/etc/selinux/config"
    content
      should match /^SELINUX=enforcing$/
  Command "getenforce"
    stdout
      should match /^Enforcing$/
  the test module source should exist and the module should be loaded
    File "/usr/share/selinux/puppet_selinux_test_policy.te"
      should be file
    Command "semodule -l | grep puppet_selinux_test_policy"
      stdout
        should match /puppet_selinux_test_policy/
  the test file should have the specified file context
    File "/tmp/test_selinux_fcontext"
      selinux_label
        should match /^.*:puppet_selinux_test_policy_exec_t:s0$/
  test boolean is available and activated
    Command "getsebool puppet_selinux_test_policy_bool"
      stdout
        should match /puppet_selinux_test_policy_bool --> on/
  test domain is permissive
    Command "semanage permissive -l"
      stdout
        should match /^puppet_selinux_test_policy_t$/
  port 55555 should have type puppet_selinux_test_policy_port_t
    Command "semanage port -l | grep puppet_selinux_test_policy_port_t"
      stdout
        should match /puppet_selinux_test_policy_port_t.*55555$/

Finished in 1 minute 56.19 seconds (files took 2 minutes 41.9 seconds to load)
11 examples, 0 failures
``` 


and F25:

```
PUPPET_INSTALL_TYPE=agent BEAKER_destroy=no  BEAKER_set=fedora-25-x64 bundle exec rspec spec/acceptance/class_spec.rb
...
selinux class
  behaves like a idempotent resource
localhost $ scp /tmp/beaker20161230-16973-1mcym6w fedora-25-x64:/tmp/apply_manifest.pp.UuwsSS {:ignore => }
    applies with no errors
localhost $ scp /tmp/beaker20161230-16973-1a2k26u fedora-25-x64:/tmp/apply_manifest.pp.YwRqA7 {:ignore => }
    applies a second time without changes
  Package "selinux-policy-targeted"
    should be installed
  File "/etc/selinux/config"
    content
      should match /^SELINUX=enforcing$/
  Command "getenforce"
    stdout
      should match /^Enforcing$/
  the test module source should exist and the module should be loaded
    File "/usr/share/selinux/puppet_selinux_test_policy.te"
      should be file
    Command "semodule -l | grep puppet_selinux_test_policy"
      stdout
        should match /puppet_selinux_test_policy/
  the test file should have the specified file context
    File "/tmp/test_selinux_fcontext"
      selinux_label
        should match /^.*:puppet_selinux_test_policy_exec_t:s0$/
  test boolean is available and activated
    Command "getsebool puppet_selinux_test_policy_bool"
      stdout
        should match /puppet_selinux_test_policy_bool --> on/
  test domain is permissive
    Command "semanage permissive -l"
      stdout
        should match /^puppet_selinux_test_policy_t$/
  port 55555 should have type puppet_selinux_test_policy_port_t
    Command "semanage port -l | grep puppet_selinux_test_policy_port_t"
      stdout
        should match /puppet_selinux_test_policy_port_t.*55555$/

Finished in 2 minutes 8.6 seconds (files took 2 minutes 37.4 seconds to load)
11 examples, 0 failures
```
