### PR TITLE
(GH-147) Add ordering of resources

### DIFF
--- a/manifests/boolean.pp
+++ b/manifests/boolean.pp
@@ -33,6 +33,10 @@ define selinux::boolean (
 
   include ::selinux
 
+  Anchor['selinux::module post'] ->
+  Selinux::Boolean[$title] ->
+  Anchor['selinux::end']
+
   $ensure_real = $ensure ? {
     true    => 'true', # lint:ignore:quoted_booleans
     false   => 'false', # lint:ignore:quoted_booleans

--- a/manifests/fcontext.pp
+++ b/manifests/fcontext.pp
@@ -79,6 +79,10 @@ define selinux::fcontext (
 
   include ::selinux
 
+  Anchor['selinux::module post'] ->
+  Selinux::Fcontext[$title] ->
+  Anchor['selinux::end']
+
   validate_absolute_path($pathname)
   validate_bool($filetype, $equals)
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -68,7 +68,8 @@ class selinux (
   class { '::selinux::package':
     manage_package => $manage_package,
     package_name   => $package_name,
-  } ->
+  }
+
   class { '::selinux::config': }
 
   if $boolean {
@@ -86,4 +87,12 @@ class selinux (
   if $port {
     create_resources ( 'selinux::port', hiera_hash('selinux::port') )
   }
+
+  # Ordering
+  anchor { 'selinux::start': } ->
+  Class['selinux::package'] ->
+  Class['selinux::config'] ->
+  anchor { 'selinux::module pre': } ->
+  anchor { 'selinux::module post': } ->
+  anchor { 'selinux::end': }
 }

--- a/manifests/module.pp
+++ b/manifests/module.pp
@@ -34,6 +34,10 @@ define selinux::module(
 
   include ::selinux
 
+  Anchor['selinux::module pre'] ->
+  Selinux::Module[$title] ->
+  Anchor['selinux::module post']
+
   validate_re($ensure, [ '^present$', '^absent$' ], '$ensure must be "present" or "absent"')
   if $ensure == 'present' and $source == undef and $content == undef {
     fail("You must provide 'source' or 'content' field for selinux module")

--- a/manifests/permissive.pp
+++ b/manifests/permissive.pp
@@ -32,6 +32,10 @@ define selinux::permissive (
 
   include ::selinux
 
+  Anchor['selinux::module post'] ->
+  Selinux::Permissive[$title] ->
+  Anchor['selinux::end']
+
   exec { "add_${context}":
     command => shellquote('semanage', 'permissive', '-a', $context),
     unless  => sprintf('semanage permissive -l | grep -Fx %s', shellquote($context)),

--- a/manifests/port.pp
+++ b/manifests/port.pp
@@ -45,6 +45,10 @@ define selinux::port (
 
   include ::selinux
 
+  Anchor['selinux::module post'] ->
+  Selinux::Port[$title] ->
+  Anchor['selinux::end']
+
   if $protocol {
     validate_re($protocol, ['^tcp6?$', '^udp6?$'])
     $protocol_switch = ['-p', $protocol]

--- a/spec/acceptance/class_spec.rb
+++ b/spec/acceptance/class_spec.rb
@@ -5,28 +5,31 @@ describe 'selinux class' do
     <<-EOS
       class { 'selinux': mode => 'enforcing' }
 
-      # with puppet4 I would use a HERE DOC to make this pretty,
-      # but with puppet3 it's not possible.
-      selinux::module { 'puppet_selinux_test_policy':
-        content => "policy_module(puppet_selinux_test_policy, 1.0.0)\ngen_tunable(puppet_selinux_test_policy_bool, false)\ntype puppet_selinux_test_policy_t;\ntype puppet_selinux_test_policy_exec_t;\ninit_daemon_domain(puppet_selinux_test_policy_t, puppet_selinux_test_policy_exec_t)\ntype puppet_selinux_test_policy_port_t;\ncorenet_port(puppet_selinux_test_policy_port_t)\n",
-        prefix => '',
-        syncversion => undef,
-      } ->
+      selinux::boolean { 'puppet_selinux_test_policy_bool': }
 
-      file { '/tmp/test_selinux_fcontext':
-        content => 'TEST',
-        seltype => 'puppet_selinux_test_policy_exec_t',
-      } ->
-
-      selinux::boolean { 'puppet_selinux_test_policy_bool': } ->
-
-      selinux::permissive { 'puppet_selinux_test_policy_t': context => 'puppet_selinux_test_policy_t', } ->
+      selinux::permissive { 'puppet_selinux_test_policy_t': context => 'puppet_selinux_test_policy_t', }
 
       selinux::port { 'puppet_selinux_test_policy_port_t/tcp':
         context => 'puppet_selinux_test_policy_port_t',
         port => '55555',
         protocol => 'tcp',
       }
+
+      # with puppet4 I would use a HERE DOC to make this pretty,
+      # but with puppet3 it's not possible.
+      selinux::module { 'puppet_selinux_test_policy':
+        content => "policy_module(puppet_selinux_test_policy, 1.0.0)\ngen_tunable(puppet_selinux_test_policy_bool, false)\ntype puppet_selinux_test_policy_t;\ntype puppet_selinux_test_policy_exec_t;\ninit_daemon_domain(puppet_selinux_test_policy_t, puppet_selinux_test_policy_exec_t)\ntype puppet_selinux_test_policy_port_t;\ncorenet_port(puppet_selinux_test_policy_port_t)\n",
+        prefix => '',
+        syncversion => undef,
+      }
+
+      Class['selinux'] ->
+
+      file { '/tmp/test_selinux_fcontext':
+        content => 'TEST',
+        seltype => 'puppet_selinux_test_policy_exec_t',
+      }
+
     EOS
   end
 

--- a/spec/classes/selinux_spec.rb
+++ b/spec/classes/selinux_spec.rb
@@ -11,6 +11,11 @@ describe 'selinux' do
       it { is_expected.to contain_class('selinux::package') }
       it { is_expected.to contain_class('selinux::config') }
       it { is_expected.to contain_class('selinux::params') }
+      it { is_expected.to contain_anchor('selinux::start').that_comes_before('Class[selinux::package]') }
+      it { is_expected.to contain_anchor('selinux::module pre').that_requires('Class[selinux::config]') }
+      it { is_expected.to contain_anchor('selinux::module pre').that_comes_before('Anchor[selinux::module post]') }
+      it { is_expected.to contain_anchor('selinux::module post').that_comes_before('Anchor[selinux::end]') }
+      it { is_expected.to contain_anchor('selinux::end').that_requires('Anchor[selinux::module post]') }
     end
   end
 end

--- a/spec/defines/selinux_boolean_spec.rb
+++ b/spec/defines/selinux_boolean_spec.rb
@@ -8,6 +8,9 @@ describe 'selinux::boolean' do
         facts
       end
 
+      it { is_expected.to contain_selinux__boolean('mybool').that_requires('Anchor[selinux::module post]') }
+      it { is_expected.to contain_selinux__boolean('mybool').that_comes_before('Anchor[selinux::end]') }
+
       ['on', true, 'present'].each do |value|
         context value do
           let(:params) do

--- a/spec/defines/selinux_fcontext_spec.rb
+++ b/spec/defines/selinux_fcontext_spec.rb
@@ -8,6 +8,17 @@ describe 'selinux::fcontext' do
         facts
       end
 
+      context 'ordering' do
+        let(:params) do
+          {
+            pathname: '/tmp/file1',
+            context: 'user_home_dir_t'
+          }
+        end
+        it { is_expected.to contain_selinux__fcontext('myfile').that_requires('Anchor[selinux::module post]') }
+        it { is_expected.to contain_selinux__fcontext('myfile').that_comes_before('Anchor[selinux::end]') }
+      end
+
       context 'invalid pathname' do
         it { expect { is_expected.to compile }.to raise_error(%r{Must pass pathname to | expects a value for parameter 'pathname'}) }
       end

--- a/spec/defines/selinux_module_spec.rb
+++ b/spec/defines/selinux_module_spec.rb
@@ -9,6 +9,16 @@ describe 'selinux::module' do
         facts
       end
 
+      context 'ordering' do
+        let(:params) do
+          {
+            source: 'puppet:///modules/mymodule/selinux/mymodule.te'
+          }
+        end
+        it { is_expected.to contain_selinux__module('mymodule').that_requires('Anchor[selinux::module pre]') }
+        it { is_expected.to contain_selinux__module('mymodule').that_comes_before('Anchor[selinux::module post]') }
+      end
+
       context 'present case' do
         let(:params) do
           {

--- a/spec/defines/selinux_permissive_spec.rb
+++ b/spec/defines/selinux_permissive_spec.rb
@@ -16,6 +16,8 @@ describe 'selinux::permissive' do
         end
         it do
           is_expected.to contain_exec('add_oddjob_mkhomedir_t').with(command: 'semanage permissive -a oddjob_mkhomedir_t')
+          is_expected.to contain_selinux__permissive('mycontextp').that_requires('Anchor[selinux::module post]')
+          is_expected.to contain_selinux__permissive('mycontextp').that_comes_before('Anchor[selinux::end]')
         end
       end
     end

--- a/spec/defines/selinux_port_spec.rb
+++ b/spec/defines/selinux_port_spec.rb
@@ -8,6 +8,18 @@ describe 'selinux::port' do
         facts
       end
 
+      context 'ordering' do
+        let(:params) do
+          {
+            context: 'http_port_t',
+            port: 8080,
+            protocol: 'tcp'
+          }
+        end
+        it { is_expected.to contain_selinux__port('myapp').that_requires('Anchor[selinux::module post]') }
+        it { is_expected.to contain_selinux__port('myapp').that_comes_before('Anchor[selinux::end]') }
+      end
+
       %w(tcp udp tcp6 udp6).each do |protocol|
         context "valid protocol #{protocol}" do
           let(:params) do


### PR DESCRIPTION
This change adds ordering of resources of this module.
    
It enables to declare resources in different manifests without
the need to care about ordering.