### PR TITLE
Add a selinux_port type and provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,10 +56,11 @@ running system.
 * While SELinux is disabled the defined types `selinux::boolean`, 
   `selinux::fcontext`, `selinux::port` will produce puppet agent runtime errors 
   because the used tools fail.
-* `selinux::port` has the `action` parameter which  if you specify `-d` or 
-  `--delete` silently does nothing. (GH-164)
 * If you try to remove a built-in permissive type, the operation will appear to succeed
   but will actually have no effect, making your puppet runs non-idempotent.
+* The `selinux_port` provider may misbehave if the title does not correspond to
+  the format it expects. Users should use the `selinux::port` define instead except
+  when purging resources
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ running system.
 * The `selinux_port` provider may misbehave if the title does not correspond to
   the format it expects. Users should use the `selinux::port` define instead except
   when purging resources
+* Defining port ranges that overlap with existing ranges is currently not detected, and will
+  cause semanage to error when the resource is applied.
 
 ## Usage
 

--- a/lib/facter/selinux_semanage_is_python3.rb
+++ b/lib/facter/selinux_semanage_is_python3.rb
@@ -1,0 +1,6 @@
+Facter.add(:selinux_semanage_is_python3) do
+  confine osfamily: 'RedHat'
+  setcode do
+    !(Facter::Core::Execution.execute('rpm -q libsemanage-python3') =~ %r{not installed})
+  end
+end

--- a/lib/puppet/provider/selinux_port/semanage.rb
+++ b/lib/puppet/provider/selinux_port/semanage.rb
@@ -5,11 +5,13 @@ Puppet::Type.type(:selinux_port).provide(:semanage) do
   # SELinux must be enabled. Is there a way to get a better error message?
   confine selinux: true
 
+  # custom fact, needed for fedora 24+
+  python_command = Facter.value(:selinux_semanage_is_python3) ? 'python3' : 'python'
   # current file path is lib/puppet/provider/selinux_port/semanage.rb
   # semanage_ports.py is lib/puppet_x/voxpupuli/selinux/semanage_ports.py
   PORTS_HELPER = File.expand_path('../../../../puppet_x/voxpupuli/selinux/semanage_ports.py', __FILE__)
   commands semanage: 'semanage',
-           python: 'python'
+           python: python_command
 
   mk_resource_methods
 

--- a/lib/puppet/provider/selinux_port/semanage.rb
+++ b/lib/puppet/provider/selinux_port/semanage.rb
@@ -1,0 +1,85 @@
+Puppet::Type.type(:selinux_port).provide(:semanage) do
+  desc 'Support managing SELinux custom port definitions via semanage'
+
+  defaultfor kernel: 'Linux'
+  # SELinux must be enabled. Is there a way to get a better error message?
+  confine selinux: true
+
+  commands semanage: 'semanage'
+
+  mk_resource_methods
+
+  def self.parse_semanage_lines(lines, source)
+    ret = {}
+    lines.each do |line|
+      split = line.split(%r{\s+})
+      context = split.shift
+      protocol = split.shift
+      # The port-range list is comma-separated
+      ports = split.map { |range| range.delete(',') }
+      # interestingly enough, it is completely valid to define a port that overlaps with a port-range,
+      # but if an existing *exact* definition exists, that causes problems
+      ports.each do |port|
+        key = "#{protocol}_#{port}"
+        ret[key] = {
+          ensure: :present,
+          name: key,
+          context: context,
+          ports: port,
+          protocol: protocol.to_sym,
+          source: source
+        }
+      end
+    end
+    ret
+  end
+
+  def self.instances
+    # no way to do this with one call as far as I know
+    custom = parse_semanage_lines(semanage('port', '--list', '--locallist', '--noheading').split("\n"), :local)
+    policy = parse_semanage_lines(semanage('port', '--list', '--noheading').split("\n"), :policy)
+    # get rid of duplicates, as --list without --locallist returns local customisations as well
+    policy.merge!(custom)
+    policy.values.map do |item|
+      new(item)
+    end
+  end
+
+  def self.prefetch(resources)
+    # is there a better way to do this? map port/protocol pairs to the provider regardless of the title
+    # and make sure all system resources have ensure => :present so that we don't try to remove them
+    instances.each do |provider|
+      resource = resources[provider.name]
+      if resource
+        unless resource[:ports] == provider.ports && resource[:protocol] == provider.protocol || resource.purging?
+          raise Puppet::ResourceError, "Selinux_port['#{resource[:name]}']: title does not match its port and protocol, and a conflicting resource exists"
+        end
+        resource.provider = provider
+        resource[:ensure] = :present if provider.source == :policy
+      else
+        resources.values.each do |res|
+          next unless res[:ports] == provider.ports && res[:protocol] == provider.protocol
+          warning("Selinux_port['#{resource[:name]}']: title does not match format protocol_port")
+          resource.provider = provider
+          resource[:ensure] = :present if provider.source == :policy
+        end
+      end
+    end
+  end
+
+  def create
+    semanage('port', '-a', '-t', @resource[:context], '-p', @resource[:protocol], @resource[:ports])
+  end
+
+  def destroy
+    semanage('port', '-d', '-p', @property_hash[:protocol], @property_hash[:ports])
+  end
+
+  def context=(val)
+    semanage('port', '-m', '-t', val, '-p', @property_hash[:protocol], @property_hash[:ports])
+  end
+
+  def exists?
+    @property_hash[:ensure] == :present
+  end
+end

--- a/lib/puppet/provider/selinux_port/semanage.rb
+++ b/lib/puppet/provider/selinux_port/semanage.rb
@@ -13,7 +13,7 @@ Puppet::Type.type(:selinux_port).provide(:semanage) do
     ret = {}
     lines.each do |line|
       split = line.split(%r{\s+})
-      context = split.shift
+      seltype = split.shift
       protocol = split.shift
       # The port-range list is comma-separated
       ports = split.map { |range| range.delete(',') }
@@ -24,7 +24,7 @@ Puppet::Type.type(:selinux_port).provide(:semanage) do
         ret[key] = {
           ensure: :present,
           name: key,
-          context: context,
+          seltype: seltype,
           ports: port,
           protocol: protocol.to_sym,
           source: source
@@ -68,14 +68,14 @@ Puppet::Type.type(:selinux_port).provide(:semanage) do
   end
 
   def create
-    semanage('port', '-a', '-t', @resource[:context], '-p', @resource[:protocol], @resource[:ports])
+    semanage('port', '-a', '-t', @resource[:seltype], '-p', @resource[:protocol], @resource[:ports])
   end
 
   def destroy
     semanage('port', '-d', '-p', @property_hash[:protocol], @property_hash[:ports])
   end
 
-  def context=(val)
+  def seltype=(val)
     semanage('port', '-m', '-t', val, '-p', @property_hash[:protocol], @property_hash[:ports])
   end
 

--- a/lib/puppet/type/selinux_port.rb
+++ b/lib/puppet/type/selinux_port.rb
@@ -33,9 +33,8 @@ Puppet::Type.newtype(:selinux_port) do
     isrequired
   end
 
-  newproperty(:context) do
-    desc 'The context of the SELinux port definition'
-    isrequired
+  newproperty(:seltype) do
+    desc 'The SELinux type of the SELinux port definition'
   end
 
   newproperty(:source) do

--- a/lib/puppet/type/selinux_port.rb
+++ b/lib/puppet/type/selinux_port.rb
@@ -33,7 +33,7 @@ Puppet::Type.newtype(:selinux_port) do
 
   newproperty(:protocol) do
     desc 'The protocol of the SELinux port definition'
-    newvalues(:tcp, :udp, :ipv4, :ipv6)
+    newvalues(:tcp, :udp)
     isrequired
   end
 

--- a/lib/puppet/type/selinux_port.rb
+++ b/lib/puppet/type/selinux_port.rb
@@ -4,25 +4,29 @@ Puppet::Type.newtype(:selinux_port) do
   ensurable
 
   newparam(:title, namevar: true) do
-    desc 'Should be of the form "protocol_port" or the type may misbehave'
+    desc 'Should be of the form "protocol_lowport-highport" or the type may misbehave'
   end
 
-  newproperty(:ports) do
-    desc 'The port or port range to manage'
+  newproperty(:low_port) do
+    desc 'The low end of the port range to manage'
     isrequired
 
-    validate do |value|
-      vals = value.split('-')
-      debug(vals)
-      vals.each do |val|
-        val = Integer(val)
-        if val < 1 || val > 65_535
-          raise ArgumentError, "Illegal port value '#{val}'"
-        end
+    validate do |val|
+      val = Integer(val)
+      if val < 1 || val > 65_535
+        raise ArgumentError, "Illegal port value '#{val}'"
       end
+    end
+  end
 
-      if (vals.count != 1) && (Integer(vals[0]) >= Integer(vals[1]))
-        raise ArgumentError, "Invalid port range #{value}"
+  newproperty(:high_port) do
+    desc 'The high end of the port range to manage'
+    isrequired
+
+    validate do |val|
+      val = Integer(val)
+      if val < 1 || val > 65_535
+        raise ArgumentError, "Illegal port value '#{val}'"
       end
     end
   end

--- a/lib/puppet/type/selinux_port.rb
+++ b/lib/puppet/type/selinux_port.rb
@@ -1,0 +1,48 @@
+Puppet::Type.newtype(:selinux_port) do
+  @doc = 'Manage SELinux port definitions. You should use selinux::port instead of this directly.'
+
+  ensurable
+
+  newparam(:title, namevar: true) do
+    desc 'Should be of the form "protocol_port" or the type may misbehave'
+  end
+
+  newproperty(:ports) do
+    desc 'The port or port range to manage'
+    isrequired
+
+    validate do |value|
+      vals = value.split('-')
+      debug(vals)
+      vals.each do |val|
+        val = Integer(val)
+        if val < 1 || val > 65_535
+          raise ArgumentError, "Illegal port value '#{val}'"
+        end
+      end
+
+      if (vals.count != 1) && (Integer(vals[0]) >= Integer(vals[1]))
+        raise ArgumentError, "Invalid port range #{value}"
+      end
+    end
+  end
+
+  newproperty(:protocol) do
+    desc 'The protocol of the SELinux port definition'
+    newvalues(:tcp, :udp, :ipv4, :ipv6)
+    isrequired
+  end
+
+  newproperty(:context) do
+    desc 'The context of the SELinux port definition'
+    isrequired
+  end
+
+  newproperty(:source) do
+    newvalues(:policy, :local)
+
+    validate do |_value|
+      raise ArgumentError, ':source is a read-only property'
+    end
+  end
+end

--- a/lib/puppet_x/voxpupuli/selinux/semanage_ports.py
+++ b/lib/puppet_x/voxpupuli/selinux/semanage_ports.py
@@ -1,0 +1,46 @@
+#!/usr/bin/python
+# This script uses libsemanage directly to access the ports list
+# it is *much* faster than semanage port -l
+
+# will work with python 2.6+
+from __future__ import print_function
+from sys import exit
+try:
+  import semanage
+except ImportError:
+  # The semanage python library does not exist, so let's assume SELinux is disabled...
+  # In this case, the correct response is to return no ports when puppet does a
+  # prefetch, to avoid an error. We depend on the semanage binary anyway, which
+  # is uses the library
+  exit(0)
+
+
+handle = semanage.semanage_handle_create()
+
+if semanage.semanage_is_managed(handle) < 0:
+    exit(1)
+if semanage.semanage_connect(handle) < 0:
+    exit(1)
+
+def print_port(kind, port):
+    con = semanage.semanage_port_get_con(port)
+    con_str = semanage.semanage_context_to_string(handle, con)
+    high = semanage.semanage_port_get_high(port)
+    low = semanage.semanage_port_get_low(port)
+    proto = semanage.semanage_port_get_proto(port)
+    proto_str = semanage.semanage_port_get_proto_str(proto)
+    print(kind, con_str[1], high, low, proto_str)
+
+# Always list local ports afterwards so that the provider works correctly
+retval, ports = semanage.semanage_port_list(handle)
+
+for port in ports:
+    print_port('policy', port)
+
+retval, ports = semanage.semanage_port_list_local(handle)
+
+for port in ports:
+    print_port('local', port)
+
+semanage.semanage_disconnect(handle)
+semanage.semanage_handle_destroy(handle)

--- a/manifests/port.pp
+++ b/manifests/port.pp
@@ -6,34 +6,40 @@
 #
 # @example Add port-context syslogd_port_t to port 8514/tcp
 #   selinux::port { 'allow-syslog-relp':
+#     ensure   => 'present',
 #     context  => 'syslogd_port_t',
 #     protocol => 'tcp',
 #     port     => '8514',
 #   }
 #
 # @param context A port-context name
-# @param protocol Either tcp or udp.
+# @param protocol Either 'tcp', 'udp', 'ipv4' or 'ipv6'
 # @param port An network port number, like '8514', or a range like '1234-4321'
-# @param argument *deprecated*, ignored
 #
 define selinux::port (
-  $context,
-  $port,
-  $ensure = 'present',
-  $protocol = undef,
-  $argument = undef,
+  String                             $context,
+  Variant[Integer[1,65535],String]   $port,
+  Enum['tcp', 'udp', 'ipv4', 'ipv6'] $protocol,
+  Enum['present', 'absent']          $ensure = 'present',
 ) {
 
   include ::selinux
 
-  Anchor['selinux::module post'] ->
-  Selinux::Port[$title] ->
-  Anchor['selinux::end']
+  if $ensure == 'present' {
+    Anchor['selinux::module post'] ->
+    Selinux::Port[$title] ->
+    Anchor['selinux::end']
+  } elsif $ensure == 'absent' {
+    Class['selinux::config'] ->
+    Selinux::Port[$title] ->
+    Anchor['selinux::module pre']
+  } else {
+    fail('Unexpected $ensure value')
+  }
 
-  validate_re($protocol, ['^tcp6?$', '^udp6?$'])
   selinux_port {"${protocol}_${port}":
     ensure   => $ensure,
-    ports    => $port,
+    ports    => $port, # type definition will validate this better in case it's a range
     context  => $context,
     protocol => $protocol,
   }

--- a/manifests/port.pp
+++ b/manifests/port.pp
@@ -2,19 +2,19 @@
 #
 # This method will manage a local network port context setting, and will
 # persist it across reboots.
-# It will perform a check to ensure the network context is not already set.
 #
 # @example Add port-context syslogd_port_t to port 8514/tcp
 #   selinux::port { 'allow-syslog-relp':
 #     ensure   => 'present',
-#     context  => 'syslogd_port_t',
+#     seltype  => 'syslogd_port_t',
 #     protocol => 'tcp',
-#     port     => '8514',
+#     port     => 8514,
 #   }
 #
-# @param context A port-context name
+# @param seltype An SELinux port type
 # @param protocol Either 'tcp', 'udp', 'ipv4' or 'ipv6'
-# @param port An network port number, like '8514', or a range like '1234-4321'
+# @param port A network port number, like 8514,
+# @param port_rage A port-range tuple, eg. [9090, 9095].
 #
 define selinux::port (
   String                             $seltype,

--- a/manifests/port.pp
+++ b/manifests/port.pp
@@ -17,7 +17,7 @@
 # @param port An network port number, like '8514', or a range like '1234-4321'
 #
 define selinux::port (
-  String                             $context,
+  String                             $seltype,
   Variant[Integer[1,65535],String]   $port,
   Enum['tcp', 'udp', 'ipv4', 'ipv6'] $protocol,
   Enum['present', 'absent']          $ensure = 'present',
@@ -40,7 +40,7 @@ define selinux::port (
   selinux_port {"${protocol}_${port}":
     ensure   => $ensure,
     ports    => $port, # type definition will validate this better in case it's a range
-    context  => $context,
+    seltype  => $seltype,
     protocol => $protocol,
   }
 }

--- a/manifests/port.pp
+++ b/manifests/port.pp
@@ -18,7 +18,7 @@
 #
 define selinux::port (
   String                             $seltype,
-  Enum['tcp', 'udp', 'ipv4', 'ipv6'] $protocol,
+  Enum['tcp', 'udp']                 $protocol,
   Optional[Integer[1,65535]]         $port = undef,
   Optional[Tuple[Integer[1,65535], 2, 2]] $port_range = undef,
   Enum['present', 'absent']          $ensure = 'present',

--- a/manifests/port.pp
+++ b/manifests/port.pp
@@ -1,4 +1,4 @@
-# selinux::fcontext
+# selinux::port
 #
 # This method will manage a local network port context setting, and will
 # persist it across reboots.
@@ -12,15 +12,16 @@
 #   }
 #
 # @param context A port-context name
-# @param protocol Either tcp or udp. If unset, omits -p flag from semanage.
-# @param port An network port number, like '8514'
-# @param argument An argument for semanage port. Default: "-a"
+# @param protocol Either tcp or udp.
+# @param port An network port number, like '8514', or a range like '1234-4321'
+# @param argument *deprecated*, ignored
 #
 define selinux::port (
   $context,
   $port,
+  $ensure = 'present',
   $protocol = undef,
-  $argument = '-a',
+  $argument = undef,
 ) {
 
   include ::selinux
@@ -29,24 +30,11 @@ define selinux::port (
   Selinux::Port[$title] ->
   Anchor['selinux::end']
 
-  validate_re("${port}", '^[0-9]+(-[0-9]+)?$') # lint:ignore:only_variable_string
-
-  if $protocol {
-    validate_re($protocol, ['^tcp$', '^udp$'])
-    $protocol_switch = ['-p', $protocol]
-    $protocol_check = "${protocol} "
-    $port_exec_command = "add_${context}_${port}_${protocol}"
-  } else {
-    $protocol_switch = []
-    $protocol_check = '' # lint:ignore:empty_string_assignment variable is used to create regexp and undef is not possible
-    $port_exec_command = "add_${context}_${port}"
-  }
-
-  exec { $port_exec_command:
-    command => shellquote('semanage', 'port', $argument, '-t', $context, $protocol_switch, "${port}"), # lint:ignore:only_variable_string port can be number and we need to force it to be string for shellquote
-    # This works because there seems to be more than one space after protocol and before first port
-    unless  => sprintf('semanage port -l | grep -E %s', shellquote("^${context}  *${protocol_check}.* ${port}(\$|,)")),
-    path    => '/bin:/sbin:/usr/bin:/usr/sbin',
-    require => Class['selinux::package'],
+  validate_re($protocol, ['^tcp6?$', '^udp6?$'])
+  selinux_port {"${protocol}_${port}":
+    ensure   => $ensure,
+    ports    => $port,
+    context  => $context,
+    protocol => $protocol,
   }
 }

--- a/spec/acceptance/class_spec.rb
+++ b/spec/acceptance/class_spec.rb
@@ -10,7 +10,7 @@ describe 'selinux class' do
       selinux::permissive { 'puppet_selinux_test_policy_t': }
 
       selinux::port { 'puppet_selinux_test_policy_port_t/tcp':
-        context => 'puppet_selinux_test_policy_port_t',
+        seltype => 'puppet_selinux_test_policy_port_t',
         port => '55555',
         protocol => 'tcp',
       }

--- a/spec/acceptance/class_spec.rb
+++ b/spec/acceptance/class_spec.rb
@@ -11,7 +11,7 @@ describe 'selinux class' do
 
       selinux::port { 'puppet_selinux_test_policy_port_t/tcp':
         seltype => 'puppet_selinux_test_policy_port_t',
-        port => '55555',
+        port => 55555,
         protocol => 'tcp',
       }
 

--- a/spec/classes/selinux_spec.rb
+++ b/spec/classes/selinux_spec.rb
@@ -53,8 +53,8 @@ describe 'selinux' do
         let(:params) do
           {
             port: {
-              'myport1' => { 'context' => 'dummy', 'port' => '444', 'protocol' => 'tcp' },
-              'myport2' => { 'context' => 'dummy', 'port' => '445', 'protocol' => 'tcp' }
+              'myport1' => { 'seltype' => 'dummy', 'port' => '444', 'protocol' => 'tcp' },
+              'myport2' => { 'seltype' => 'dummy', 'port' => '445', 'protocol' => 'tcp' }
             }
           }
         end

--- a/spec/classes/selinux_spec.rb
+++ b/spec/classes/selinux_spec.rb
@@ -53,8 +53,8 @@ describe 'selinux' do
         let(:params) do
           {
             port: {
-              'myport1' => { 'seltype' => 'dummy', 'port' => '444', 'protocol' => 'tcp' },
-              'myport2' => { 'seltype' => 'dummy', 'port' => '445', 'protocol' => 'tcp' }
+              'myport1' => { 'seltype' => 'dummy', 'port' => 444, 'protocol' => 'tcp' },
+              'myport2' => { 'seltype' => 'dummy', 'port' => 445, 'protocol' => 'tcp' }
             }
           }
         end

--- a/spec/defines/selinux_port_spec.rb
+++ b/spec/defines/selinux_port_spec.rb
@@ -11,7 +11,7 @@ describe 'selinux::port' do
       context 'ordering' do
         let(:params) do
           {
-            context: 'http_port_t',
+            seltype: 'http_port_t',
             port: 8080,
             protocol: 'tcp'
           }
@@ -24,29 +24,29 @@ describe 'selinux::port' do
         context "valid protocol #{protocol}" do
           let(:params) do
             {
-              context: 'http_port_t',
+              seltype: 'http_port_t',
               port: 8080,
               protocol: protocol
             }
           end
-          it { is_expected.to contain_selinux_port("#{protocol}_8080").with(context: 'http_port_t') }
+          it { is_expected.to contain_selinux_port("#{protocol}_8080").with(seltype: 'http_port_t') }
         end
         context "protocol #{protocol} and port as range" do
           let(:params) do
             {
-              context: 'http_port_t',
+              seltype: 'http_port_t',
               port: '8080-8089',
               protocol: protocol
             }
           end
-          it { is_expected.to contain_selinux_port("#{protocol}_8080-8089").with(context: 'http_port_t') }
+          it { is_expected.to contain_selinux_port("#{protocol}_8080-8089").with(seltype: 'http_port_t') }
         end
       end
 
       context 'invalid protocol' do
         let(:params) do
           {
-            context: 'http_port_t',
+            seltype: 'http_port_t',
             port: 8080,
             protocol: 'bad'
           }
@@ -57,7 +57,7 @@ describe 'selinux::port' do
       context 'no protocol' do
         let(:params) do
           {
-            context: 'http_port_t',
+            seltype: 'http_port_t',
             port: 8080
           }
         end

--- a/spec/defines/selinux_port_spec.rb
+++ b/spec/defines/selinux_port_spec.rb
@@ -20,7 +20,7 @@ describe 'selinux::port' do
         it { is_expected.to contain_selinux__port('myapp').that_comes_before('Anchor[selinux::end]') }
       end
 
-      %w(tcp udp).each do |protocol|
+      %w(tcp udp ipv4 ipv6).each do |protocol|
         context "valid protocol #{protocol}" do
           let(:params) do
             {
@@ -29,7 +29,7 @@ describe 'selinux::port' do
               protocol: protocol
             }
           end
-          it { is_expected.to contain_exec("add_http_port_t_8080_#{protocol}").with(command: "semanage port -a -t http_port_t -p #{protocol} 8080") }
+          it { is_expected.to contain_selinux_port("#{protocol}_8080").with(context: 'http_port_t') }
         end
         context "protocol #{protocol} and port as range" do
           let(:params) do
@@ -39,7 +39,7 @@ describe 'selinux::port' do
               protocol: protocol
             }
           end
-          it { is_expected.to contain_exec("add_http_port_t_8080-8089_#{protocol}").with(command: "semanage port -a -t http_port_t -p #{protocol} 8080-8089") }
+          it { is_expected.to contain_selinux_port("#{protocol}_8080-8089").with(context: 'http_port_t') }
         end
       end
 
@@ -61,7 +61,7 @@ describe 'selinux::port' do
             port: 8080
           }
         end
-        it { is_expected.to contain_exec('add_http_port_t_8080').with(command: 'semanage port -a -t http_port_t 8080') }
+        it { expect { is_expected.to compile }.to raise_error(%r{error during compilation}) }
       end
     end
   end

--- a/spec/defines/selinux_port_spec.rb
+++ b/spec/defines/selinux_port_spec.rb
@@ -29,13 +29,13 @@ describe 'selinux::port' do
               protocol: protocol
             }
           end
-          it { is_expected.to contain_selinux_port("#{protocol}_8080").with(seltype: 'http_port_t') }
+          it { is_expected.to contain_selinux_port("#{protocol}_8080-8080").with(seltype: 'http_port_t') }
         end
-        context "protocol #{protocol} and port as range" do
+        context "protocol #{protocol} and port_range" do
           let(:params) do
             {
               seltype: 'http_port_t',
-              port: '8080-8089',
+              port_range: [8080, 8089],
               protocol: protocol
             }
           end
@@ -49,6 +49,18 @@ describe 'selinux::port' do
             seltype: 'http_port_t',
             port: 8080,
             protocol: 'bad'
+          }
+        end
+        it { expect { is_expected.to compile }.to raise_error(%r{error during compilation}) }
+      end
+
+      context 'both port and port_range' do
+        let(:params) do
+          {
+            seltype: 'http_port_t',
+            port: 8080,
+            port_range: [8080, 8081],
+            protocol: 'tcp'
           }
         end
         it { expect { is_expected.to compile }.to raise_error(%r{error during compilation}) }

--- a/spec/defines/selinux_port_spec.rb
+++ b/spec/defines/selinux_port_spec.rb
@@ -20,7 +20,7 @@ describe 'selinux::port' do
         it { is_expected.to contain_selinux__port('myapp').that_comes_before('Anchor[selinux::end]') }
       end
 
-      %w(tcp udp ipv4 ipv6).each do |protocol|
+      %w(tcp udp).each do |protocol|
         context "valid protocol #{protocol}" do
           let(:params) do
             {

--- a/spec/unit/provider/selinux_port/semanage_spec.rb
+++ b/spec/unit/provider/selinux_port/semanage_spec.rb
@@ -1,0 +1,171 @@
+require 'spec_helper'
+
+semanage_provider = Puppet::Type.type(:selinux_port).provider(:semanage)
+port = Puppet::Type.type(:selinux_port)
+
+# 23 lines:
+ports_helper_output = <<-EOS
+policy system_u:object_r:ipp_port_t:s0 8614 8610 tcp
+policy system_u:object_r:ipp_port_t:s0 8614 8610 udp
+policy system_u:object_r:pki_ca_port_t:s0 9447 9443 tcp
+policy system_u:object_r:gluster_port_t:s0 38469 38465 tcp
+policy system_u:object_r:http_cache_port_t:s0 10010 10001 tcp
+policy system_u:object_r:traceroute_port_t:s0 64010 64000 udp
+policy system_u:object_r:vnc_port_t:s0 5999 5985 tcp
+policy system_u:object_r:cyphesis_port_t:s0 6799 6780 tcp
+policy system_u:object_r:xserver_port_t:s0 6020 6000 tcp
+policy system_u:object_r:gluster_port_t:s0 24027 24007 tcp
+policy system_u:object_r:mysqld_port_t:s0 63164 63132 tcp
+policy system_u:object_r:virt_migration_port_t:s0 49216 49152 tcp
+policy system_u:object_r:vnc_port_t:s0 5983 5900 tcp
+policy system_u:object_r:unreserved_port_t:s0 65535 61001 tcp
+policy system_u:object_r:unreserved_port_t:s0 65535 61001 udp
+policy system_u:object_r:ephemeral_port_t:s0 61000 32768 tcp
+policy system_u:object_r:ephemeral_port_t:s0 61000 32768 udp
+policy system_u:object_r:unreserved_port_t:s0 32767 1024 tcp
+policy system_u:object_r:unreserved_port_t:s0 32767 1024 udp
+local system_u:object_r:zope_port_t:s0 12345 12345 tcp
+local system_u:object_r:zope_port_t:s0 12345 12345 udp
+local system_u:object_r:zookeeper_client_port_t:s0 15132 15123 udp
+local system_u:object_r:zookeeper_client_port_t:s0 15132 15123 tcp
+EOS
+
+# END 23 instances
+
+instance_examples = {
+  0 => {
+    ensure: :present,
+    name: 'tcp_8610-8614',
+    protocol: :tcp,
+    seltype: 'ipp_port_t',
+    high_port: '8614',
+    low_port: '8610',
+    source: :policy
+  },
+  1 => {
+    ensure: :present,
+    name: 'udp_8610-8614',
+    protocol: :udp,
+    seltype: 'ipp_port_t',
+    high_port: '8614',
+    low_port: '8610',
+    source: :policy
+  },
+  20 => {
+    ensure: :present,
+    name: 'udp_12345-12345',
+    protocol: :udp,
+    seltype: 'zope_port_t',
+    high_port: '12345',
+    low_port: '12345',
+    source: :local
+  },
+  21 => {
+    ensure: :present,
+    name: 'udp_15123-15132',
+    protocol: :udp,
+    seltype: 'zookeeper_client_port_t',
+    high_port: '15132',
+    low_port: '15123',
+    source: :local
+  },
+  22 => {
+    ensure: :present,
+    name: 'tcp_15123-15132',
+    protocol: :tcp,
+    seltype: 'zookeeper_client_port_t',
+    high_port: '15132',
+    low_port: '15123',
+    source: :local
+  }
+}
+
+# remove the source key as it's supposed to error out
+resource_example = instance_examples[22].clone
+resource_example.delete(:source)
+
+describe semanage_provider do
+  on_supported_os.each do |os, _facts|
+    context "on #{os}" do
+      context 'with some local port definitions' do
+        before do
+          # Call to python helper script
+          semanage_provider.expects(:python).returns(ports_helper_output)
+        end
+        it 'returns 23 resources' do
+          expect(described_class.instances.size).to eq(23)
+        end
+        instance_examples.each do |index, hash|
+          it "parses example #{index} correctly" do
+            expect(described_class.instances[index].instance_variable_get('@property_hash')).to eq(hash)
+          end
+        end
+      end
+      context 'creating' do
+        let(:resource) do
+          res = port.new(resource_example)
+          res.provider = semanage_provider.new
+          res
+        end
+        it 'runs semanage port -a for a port range' do
+          described_class.expects(:semanage).with('port', '-a', '-t', 'zookeeper_client_port_t', '-p', :tcp, '15123-15132')
+          resource.provider.create
+        end
+        it 'runs semanage port -a for a single port' do
+          resource[:high_port] = resource[:low_port]
+          described_class.expects(:semanage).with('port', '-a', '-t', 'zookeeper_client_port_t', '-p', :tcp, '15123')
+          resource.provider.create
+        end
+      end
+      context 'deleting' do
+        let(:res_port_range) do
+          res = port.new(resource_example)
+          res.provider = semanage_provider.new(resource_example)
+          res
+        end
+        let(:res_single_port) do
+          ex = resource_example.clone
+          ex[:high_port] = ex[:low_port]
+          res = port.new(ex)
+          res.provider = semanage_provider.new(ex)
+          res
+        end
+        it 'runs semanage port -d for a port range' do
+          described_class.expects(:semanage).with('port', '-d', '-p', :tcp, '15123-15132')
+          res_port_range.provider.destroy
+        end
+        it 'runs semanage port -d for a single port' do
+          described_class.expects(:semanage).with('port', '-d', '-p', :tcp, '15123')
+          res_single_port.provider.destroy
+        end
+      end
+      context 'with resources differing from the catalog' do
+        let(:resources) do
+          {
+            'tcp_54321-54321' => port.new(
+              name: 'tcp_54321-54321',
+              protocol: :tcp,
+              seltype: 'ipp_port_t',
+              high_port: '54321',
+              low_port: '54321'
+            ),
+            'tcp_15123-15132' => port.new(resource_example)
+          }
+        end
+        before do
+          # prefetch:
+          semanage_provider.expects(:python).returns(ports_helper_output)
+          semanage_provider.prefetch(resources)
+        end
+        context 'prefetch finds the provider for tcp_15123-15132 (resource example)' do
+          let(:p) { resources['tcp_15123-15132'].provider }
+          it { expect(p.name).to eq('tcp_15123-15132') }
+          it { expect(p.protocol).to eq(:tcp) }
+          it { expect(p.seltype).to eq('zookeeper_client_port_t') }
+          it { expect(p.high_port).to eq('15132') }
+          it { expect(p.low_port).to eq('15123') }
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
The selinux module currently handles port resources (among others) via exec resources, and this leads to various issues.

I though I'd practice a bit and implemented a selinux_port type and a semanage provider for the same which supports managing these "natively"

The code is still a work-in-progress. There are no tests, for example, since I'm not very experienced with ruby and I find the DSLs quite confusing... I did some manual testing and it seems to work as expected.

At any rate I would like some feedback before I proceed, especially on the prefetch implementation in the provider. I can't shake the feeling that there should be a better way to do it than what I currently have, but I honestly can't tell.

Using a type should fix at least #119, #164, #93 and #38