### PR TITLE
(GH-148) Use declared parameters

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -73,19 +73,19 @@ class selinux (
   class { '::selinux::config': }
 
   if $boolean {
-    create_resources ( 'selinux::boolean', hiera_hash('selinux::boolean') )
+    create_resources ( 'selinux::boolean', hiera_hash('selinux::boolean', $boolean) )
   }
   if $fcontext {
-    create_resources ( 'selinux::fcontext', hiera_hash('selinux::fcontext') )
+    create_resources ( 'selinux::fcontext', hiera_hash('selinux::fcontext', $fcontext) )
   }
   if $module {
-    create_resources ( 'selinux::module', hiera_hash('selinux::module') )
+    create_resources ( 'selinux::module', hiera_hash('selinux::module', $module) )
   }
   if $permissive {
-    create_resources ( 'selinux::fcontext', hiera_hash('selinux::permissive') )
+    create_resources ( 'selinux::fcontext', hiera_hash('selinux::permissive', $permissive) )
   }
   if $port {
-    create_resources ( 'selinux::port', hiera_hash('selinux::port') )
+    create_resources ( 'selinux::port', hiera_hash('selinux::port', $port) )
   }
 
   # Ordering

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -82,7 +82,7 @@ class selinux (
     create_resources ( 'selinux::module', hiera_hash('selinux::module', $module) )
   }
   if $permissive {
-    create_resources ( 'selinux::fcontext', hiera_hash('selinux::permissive', $permissive) )
+    create_resources ( 'selinux::permissive', hiera_hash('selinux::permissive', $permissive) )
   }
   if $port {
     create_resources ( 'selinux::port', hiera_hash('selinux::port', $port) )

--- a/spec/classes/selinux_spec.rb
+++ b/spec/classes/selinux_spec.rb
@@ -8,6 +8,10 @@ describe 'selinux' do
       end
       it { is_expected.to contain_class('selinux').without_mode }
       it { is_expected.to contain_class('selinux').without_type }
+      it { is_expected.to contain_class('selinux').without_module }
+      it { is_expected.to contain_class('selinux').without_port }
+      it { is_expected.to contain_class('selinux').without_fcontext }
+      it { is_expected.to contain_class('selinux').without_permissive }
       it { is_expected.to contain_class('selinux::package') }
       it { is_expected.to contain_class('selinux::config') }
       it { is_expected.to contain_class('selinux::params') }
@@ -16,6 +20,76 @@ describe 'selinux' do
       it { is_expected.to contain_anchor('selinux::module pre').that_comes_before('Anchor[selinux::module post]') }
       it { is_expected.to contain_anchor('selinux::module post').that_comes_before('Anchor[selinux::end]') }
       it { is_expected.to contain_anchor('selinux::end').that_requires('Anchor[selinux::module post]') }
+
+      context 'with module resources defined' do
+        let(:params) do
+          {
+            module: {
+              'mymodule1' =>  { 'content' => 'dummy' },
+              'mymodule2' =>  { 'content' => 'dummy' }
+            }
+          }
+        end
+
+        it { is_expected.to contain_selinux__module('mymodule1') }
+        it { is_expected.to contain_selinux__module('mymodule2') }
+      end
+
+      context 'with boolean resources defined' do
+        let(:params) do
+          {
+            boolean: {
+              'mybool1' => {},
+              'mybool2' => {}
+            }
+          }
+        end
+
+        it { is_expected.to contain_selinux__boolean('mybool1') }
+        it { is_expected.to contain_selinux__boolean('mybool2') }
+      end
+
+      context 'with port resources defined' do
+        let(:params) do
+          {
+            port: {
+              'myport1' => { 'context' => 'dummy', 'port' => '444', 'protocol' => 'tcp' },
+              'myport2' => { 'context' => 'dummy', 'port' => '445', 'protocol' => 'tcp' }
+            }
+          }
+        end
+
+        it { is_expected.to contain_selinux__port('myport1') }
+        it { is_expected.to contain_selinux__port('myport2') }
+      end
+
+      context 'with permissive resources defined' do
+        let(:params) do
+          {
+            permissive: {
+              'domain1' => { 'context' => 'domain1' },
+              'domain2' => { 'context' => 'domain2' }
+            }
+          }
+        end
+
+        it { is_expected.to contain_selinux__permissive('domain1') }
+        it { is_expected.to contain_selinux__permissive('domain2') }
+      end
+
+      context 'with fcontext resources defined' do
+        let(:params) do
+          {
+            fcontext: {
+              'myfcontext1' => { 'context' => 'mysqld_log_t', 'pathname' => '/u01/log/mysql(/.*)?' },
+              'myfcontext2' => { 'context' => 'mysqld_log_t', 'pathname' => '/u02/log/mysql(/.*)?' }
+            }
+          }
+        end
+
+        it { is_expected.to contain_selinux__fcontext('myfcontext1') }
+        it { is_expected.to contain_selinux__fcontext('myfcontext2') }
+      end
     end
   end
 end


### PR DESCRIPTION
Until now only hiera was quieried for class module, port, fcontext, and permissive parameters. 

If anybody declared the class in puppet code they would not have been used. 

This change uses the passed parameters if hiera_hash() doesn't find values in hiera.

An additional fix is to not use selinux::fcontext with the permissive parameter.

Additional tests are now included to check if resources are created. 