### PR TITLE
(GH-119) Don't accept udp6 and tcp6 as protocol name with selinux::port

### DIFF
--- a/manifests/port.pp
+++ b/manifests/port.pp
@@ -29,8 +29,10 @@ define selinux::port (
   Selinux::Port[$title] ->
   Anchor['selinux::end']
 
+  validate_re("${port}", '^[0-9]+(-[0-9]+)?$') # lint:ignore:only_variable_string
+
   if $protocol {
-    validate_re($protocol, ['^tcp6?$', '^udp6?$'])
+    validate_re($protocol, ['^tcp$', '^udp$'])
     $protocol_switch = ['-p', $protocol]
     $protocol_check = "${protocol} "
     $port_exec_command = "add_${context}_${port}_${protocol}"

--- a/spec/defines/selinux_port_spec.rb
+++ b/spec/defines/selinux_port_spec.rb
@@ -20,7 +20,7 @@ describe 'selinux::port' do
         it { is_expected.to contain_selinux__port('myapp').that_comes_before('Anchor[selinux::end]') }
       end
 
-      %w(tcp udp tcp6 udp6).each do |protocol|
+      %w(tcp udp).each do |protocol|
         context "valid protocol #{protocol}" do
           let(:params) do
             {


### PR DESCRIPTION
Only udp and tcp are valid. ipv4 and ipv6 would be valid options too
but it wasn't provided before.

This change closes #119