### PR TITLE
(WIP) Release 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Change Log
 
+## 2017-01-18 - Release 1.0.0
+
+This release marks the interface of this module as stable.
+
+The 1.x series will only accept bugfixes and added deprecation notices.
+
+The 2.0.0 release is already on its way. It will introduce breaking changes
+like being Puppet 4 only, native puppet types and consistent naming of
+parameters.
+
+Notable changes in this release:
+
+* Bugfix: (GH-148) Make use of class selinux parameters
+* Bugfix: (GH-119) Don't accept udp6 and tcp6 as protocol name with selinux::port
+* Enhancement: Updated inline documentation to puppet strings
+* Enhancement: (GH-147) Add ordering of resources
+
 ## 2017-01-12 - Release 0.8.0
 
 This is the last release with Puppet 3 support!

--- a/docs/_index.html
+++ b/docs/_index.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>
-  Documentation by YARD 0.9.7
+  Documentation by YARD 0.9.8
   
 </title>
 
@@ -52,7 +52,7 @@
         <div class="clear"></div>
       </div>
 
-      <div id="content"><h1 class="noborder title">Documentation by YARD 0.9.7</h1>
+      <div id="content"><h1 class="noborder title">Documentation by YARD 0.9.8</h1>
 <div id="listing">
   <h1 class="alphaindex">Alphabetic Index</h1>
   
@@ -181,9 +181,9 @@
 </div>
 
       <div id="footer">
-  Generated on Fri Jan 13 15:43:22 2017 by
+  Generated on Wed Jan 18 21:43:24 2017 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
-  0.9.7 (ruby-2.3.3).
+  0.9.8 (ruby-2.3.3).
 </div>
 
     </div>

--- a/docs/file.README.html
+++ b/docs/file.README.html
@@ -6,7 +6,7 @@
 <title>
   File: README
   
-    &mdash; Documentation by YARD 0.9.7
+    &mdash; Documentation by YARD 0.9.8
   
 </title>
 
@@ -125,11 +125,10 @@ remove it. (GH-165)</li>
 
 <h2>Usage</h2>
 
-<p>There is puppet-strings generated documentation available in the docs/ folder 
-of the github repo.</p>
+<p>Generated puppet strings documentation with examples is available from
+<a href="https://voxpupuli.org/puppet-selinux/">https://voxpupuli.org/puppet-selinux/</a></p>
 
-<p>It will be available at <a href="http://voxpupuli.org/pupppet-selinux">http://voxpupuli.org/pupppet-selinux</a> some time in 
-the future.</p>
+<p>It&#39;s also included in the docs/ folder as simple html pages.</p>
 
 <h2>Reference</h2>
 
@@ -239,9 +238,9 @@ the config_mode to be set, but only the boolean <code>enabled</code> is set.</p>
 </div></div>
 
       <div id="footer">
-  Generated on Fri Jan 13 15:43:22 2017 by
+  Generated on Wed Jan 18 21:43:24 2017 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
-  0.9.7 (ruby-2.3.3).
+  0.9.8 (ruby-2.3.3).
 </div>
 
     </div>

--- a/docs/frames.html
+++ b/docs/frames.html
@@ -2,7 +2,7 @@
 <html>
 <head>
   <meta charset="utf-8">
-	<title>Documentation by YARD 0.9.7</title>
+	<title>Documentation by YARD 0.9.8</title>
 </head>
 <script type="text/javascript" charset="utf-8">
   var match = unescape(window.location.hash).match(/^#!(.+)/);

--- a/docs/index.html
+++ b/docs/index.html
@@ -6,7 +6,7 @@
 <title>
   File: README
   
-    &mdash; Documentation by YARD 0.9.7
+    &mdash; Documentation by YARD 0.9.8
   
 </title>
 
@@ -125,11 +125,10 @@ remove it. (GH-165)</li>
 
 <h2>Usage</h2>
 
-<p>There is puppet-strings generated documentation available in the docs/ folder 
-of the github repo.</p>
+<p>Generated puppet strings documentation with examples is available from
+<a href="https://voxpupuli.org/puppet-selinux/">https://voxpupuli.org/puppet-selinux/</a></p>
 
-<p>It will be available at <a href="http://voxpupuli.org/pupppet-selinux">http://voxpupuli.org/pupppet-selinux</a> some time in 
-the future.</p>
+<p>It&#39;s also included in the docs/ folder as simple html pages.</p>
 
 <h2>Reference</h2>
 
@@ -239,9 +238,9 @@ the config_mode to be set, but only the boolean <code>enabled</code> is set.</p>
 </div></div>
 
       <div id="footer">
-  Generated on Fri Jan 13 15:43:22 2017 by
+  Generated on Wed Jan 18 21:43:24 2017 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
-  0.9.7 (ruby-2.3.3).
+  0.9.8 (ruby-2.3.3).
 </div>
 
     </div>

--- a/docs/puppet_classes/selinux.html
+++ b/docs/puppet_classes/selinux.html
@@ -6,7 +6,7 @@
 <title>
   Puppet Class: selinux
   
-    &mdash; Documentation by YARD 0.9.7
+    &mdash; Documentation by YARD 0.9.8
   
 </title>
 
@@ -422,19 +422,19 @@ class selinux (
   class { &#39;::selinux::config&#39;: }
 
   if $boolean {
-    create_resources ( &#39;selinux::boolean&#39;, hiera_hash(&#39;selinux::boolean&#39;) )
+    create_resources ( &#39;selinux::boolean&#39;, hiera_hash(&#39;selinux::boolean&#39;, $boolean) )
   }
   if $fcontext {
-    create_resources ( &#39;selinux::fcontext&#39;, hiera_hash(&#39;selinux::fcontext&#39;) )
+    create_resources ( &#39;selinux::fcontext&#39;, hiera_hash(&#39;selinux::fcontext&#39;, $fcontext) )
   }
   if $module {
-    create_resources ( &#39;selinux::module&#39;, hiera_hash(&#39;selinux::module&#39;) )
+    create_resources ( &#39;selinux::module&#39;, hiera_hash(&#39;selinux::module&#39;, $module) )
   }
   if $permissive {
-    create_resources ( &#39;selinux::fcontext&#39;, hiera_hash(&#39;selinux::permissive&#39;) )
+    create_resources ( &#39;selinux::permissive&#39;, hiera_hash(&#39;selinux::permissive&#39;, $permissive) )
   }
   if $port {
-    create_resources ( &#39;selinux::port&#39;, hiera_hash(&#39;selinux::port&#39;) )
+    create_resources ( &#39;selinux::port&#39;, hiera_hash(&#39;selinux::port&#39;, $port) )
   }
 
   # Ordering
@@ -452,9 +452,9 @@ class selinux (
 </div>
 
       <div id="footer">
-  Generated on Fri Jan 13 15:43:22 2017 by
+  Generated on Wed Jan 18 21:43:24 2017 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
-  0.9.7 (ruby-2.3.3).
+  0.9.8 (ruby-2.3.3).
 </div>
 
     </div>

--- a/docs/puppet_classes/selinux_3A_3Aconfig.html
+++ b/docs/puppet_classes/selinux_3A_3Aconfig.html
@@ -6,7 +6,7 @@
 <title>
   Puppet Class: selinux::config
   
-    &mdash; Documentation by YARD 0.9.7
+    &mdash; Documentation by YARD 0.9.8
   
 </title>
 
@@ -327,9 +327,9 @@ class selinux::config (
 </div>
 
       <div id="footer">
-  Generated on Fri Jan 13 15:43:22 2017 by
+  Generated on Wed Jan 18 21:43:24 2017 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
-  0.9.7 (ruby-2.3.3).
+  0.9.8 (ruby-2.3.3).
 </div>
 
     </div>

--- a/docs/puppet_classes/selinux_3A_3Apackage.html
+++ b/docs/puppet_classes/selinux_3A_3Apackage.html
@@ -6,7 +6,7 @@
 <title>
   Puppet Class: selinux::package
   
-    &mdash; Documentation by YARD 0.9.7
+    &mdash; Documentation by YARD 0.9.8
   
 </title>
 
@@ -162,9 +162,9 @@ class selinux::package (
 </div>
 
       <div id="footer">
-  Generated on Fri Jan 13 15:43:22 2017 by
+  Generated on Wed Jan 18 21:43:24 2017 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
-  0.9.7 (ruby-2.3.3).
+  0.9.8 (ruby-2.3.3).
 </div>
 
     </div>

--- a/docs/puppet_classes/selinux_3A_3Aparams.html
+++ b/docs/puppet_classes/selinux_3A_3Aparams.html
@@ -6,7 +6,7 @@
 <title>
   Puppet Class: selinux::params
   
-    &mdash; Documentation by YARD 0.9.7
+    &mdash; Documentation by YARD 0.9.8
   
 </title>
 
@@ -279,9 +279,9 @@ class selinux::params {
 </div>
 
       <div id="footer">
-  Generated on Fri Jan 13 15:43:22 2017 by
+  Generated on Wed Jan 18 21:43:24 2017 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
-  0.9.7 (ruby-2.3.3).
+  0.9.8 (ruby-2.3.3).
 </div>
 
     </div>

--- a/docs/puppet_classes/selinux_3A_3Arestorecond.html
+++ b/docs/puppet_classes/selinux_3A_3Arestorecond.html
@@ -6,7 +6,7 @@
 <title>
   Puppet Class: selinux::restorecond
   
-    &mdash; Documentation by YARD 0.9.7
+    &mdash; Documentation by YARD 0.9.8
   
 </title>
 
@@ -201,9 +201,9 @@ class selinux::restorecond (
 </div>
 
       <div id="footer">
-  Generated on Fri Jan 13 15:43:22 2017 by
+  Generated on Wed Jan 18 21:43:24 2017 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
-  0.9.7 (ruby-2.3.3).
+  0.9.8 (ruby-2.3.3).
 </div>
 
     </div>

--- a/docs/puppet_classes/selinux_3A_3Arestorecond_3A_3Aconfig.html
+++ b/docs/puppet_classes/selinux_3A_3Arestorecond_3A_3Aconfig.html
@@ -6,7 +6,7 @@
 <title>
   Puppet Class: selinux::restorecond::config
   
-    &mdash; Documentation by YARD 0.9.7
+    &mdash; Documentation by YARD 0.9.8
   
 </title>
 
@@ -132,9 +132,9 @@ class selinux::restorecond::config {
 </div>
 
       <div id="footer">
-  Generated on Fri Jan 13 15:43:22 2017 by
+  Generated on Wed Jan 18 21:43:24 2017 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
-  0.9.7 (ruby-2.3.3).
+  0.9.8 (ruby-2.3.3).
 </div>
 
     </div>

--- a/docs/puppet_classes/selinux_3A_3Arestorecond_3A_3Aservice.html
+++ b/docs/puppet_classes/selinux_3A_3Arestorecond_3A_3Aservice.html
@@ -6,7 +6,7 @@
 <title>
   Puppet Class: selinux::restorecond::service
   
-    &mdash; Documentation by YARD 0.9.7
+    &mdash; Documentation by YARD 0.9.8
   
 </title>
 
@@ -116,9 +116,9 @@ class selinux::restorecond::service {
 </div>
 
       <div id="footer">
-  Generated on Fri Jan 13 15:43:22 2017 by
+  Generated on Wed Jan 18 21:43:24 2017 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
-  0.9.7 (ruby-2.3.3).
+  0.9.8 (ruby-2.3.3).
 </div>
 
     </div>

--- a/docs/puppet_defined_types/selinux_3A_3Aboolean.html
+++ b/docs/puppet_defined_types/selinux_3A_3Aboolean.html
@@ -6,7 +6,7 @@
 <title>
   Defined Type: selinux::boolean
   
-    &mdash; Documentation by YARD 0.9.7
+    &mdash; Documentation by YARD 0.9.8
   
 </title>
 
@@ -219,9 +219,9 @@ define selinux::boolean (
 </div>
 
       <div id="footer">
-  Generated on Fri Jan 13 15:43:22 2017 by
+  Generated on Wed Jan 18 21:43:24 2017 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
-  0.9.7 (ruby-2.3.3).
+  0.9.8 (ruby-2.3.3).
 </div>
 
     </div>

--- a/docs/puppet_defined_types/selinux_3A_3Afcontext.html
+++ b/docs/puppet_defined_types/selinux_3A_3Afcontext.html
@@ -6,7 +6,7 @@
 <title>
   Defined Type: selinux::fcontext
   
-    &mdash; Documentation by YARD 0.9.7
+    &mdash; Documentation by YARD 0.9.8
   
 </title>
 
@@ -483,9 +483,9 @@ define selinux::fcontext (
 </div>
 
       <div id="footer">
-  Generated on Fri Jan 13 15:43:22 2017 by
+  Generated on Wed Jan 18 21:43:24 2017 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
-  0.9.7 (ruby-2.3.3).
+  0.9.8 (ruby-2.3.3).
 </div>
 
     </div>

--- a/docs/puppet_defined_types/selinux_3A_3Amodule.html
+++ b/docs/puppet_defined_types/selinux_3A_3Amodule.html
@@ -6,7 +6,7 @@
 <title>
   Defined Type: selinux::module
   
-    &mdash; Documentation by YARD 0.9.7
+    &mdash; Documentation by YARD 0.9.8
   
 </title>
 
@@ -360,9 +360,9 @@ define selinux::module(
 </div>
 
       <div id="footer">
-  Generated on Fri Jan 13 15:43:22 2017 by
+  Generated on Wed Jan 18 21:43:24 2017 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
-  0.9.7 (ruby-2.3.3).
+  0.9.8 (ruby-2.3.3).
 </div>
 
     </div>

--- a/docs/puppet_defined_types/selinux_3A_3Apermissive.html
+++ b/docs/puppet_defined_types/selinux_3A_3Apermissive.html
@@ -6,7 +6,7 @@
 <title>
   Defined Type: selinux::permissive
   
-    &mdash; Documentation by YARD 0.9.7
+    &mdash; Documentation by YARD 0.9.8
   
 </title>
 
@@ -164,9 +164,9 @@ define selinux::permissive (
 </div>
 
       <div id="footer">
-  Generated on Fri Jan 13 15:43:22 2017 by
+  Generated on Wed Jan 18 21:43:24 2017 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
-  0.9.7 (ruby-2.3.3).
+  0.9.8 (ruby-2.3.3).
 </div>
 
     </div>

--- a/docs/puppet_defined_types/selinux_3A_3Aport.html
+++ b/docs/puppet_defined_types/selinux_3A_3Aport.html
@@ -6,7 +6,7 @@
 <title>
   Defined Type: selinux::port
   
-    &mdash; Documentation by YARD 0.9.7
+    &mdash; Documentation by YARD 0.9.8
   
 </title>
 
@@ -203,7 +203,9 @@ It will perform a check to ensure the network context is not already set.</p>
 47
 48
 49
-50</pre>
+50
+51
+52</pre>
       </td>
       <td>
         <pre class="code"><span class="info file"># File 'manifests/port.pp', line 19</span>
@@ -221,8 +223,10 @@ define selinux::port (
   Selinux::Port[$title] -&gt;
   Anchor[&#39;selinux::end&#39;]
 
+  validate_re(&quot;${port}&quot;, &#39;^[0-9]+(-[0-9]+)?$&#39;) # lint:ignore:only_variable_string
+
   if $protocol {
-    validate_re($protocol, [&#39;^tcp6?$&#39;, &#39;^udp6?$&#39;])
+    validate_re($protocol, [&#39;^tcp$&#39;, &#39;^udp$&#39;])
     $protocol_switch = [&#39;-p&#39;, $protocol]
     $protocol_check = &quot;${protocol} &quot;
     $port_exec_command = &quot;add_${context}_${port}_${protocol}&quot;
@@ -247,9 +251,9 @@ define selinux::port (
 </div>
 
       <div id="footer">
-  Generated on Fri Jan 13 15:43:22 2017 by
+  Generated on Wed Jan 18 21:43:24 2017 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
-  0.9.7 (ruby-2.3.3).
+  0.9.8 (ruby-2.3.3).
 </div>
 
     </div>

--- a/docs/puppet_defined_types/selinux_3A_3Arestorecond_3A_3Afragment.html
+++ b/docs/puppet_defined_types/selinux_3A_3Arestorecond_3A_3Afragment.html
@@ -6,7 +6,7 @@
 <title>
   Defined Type: selinux::restorecond::fragment
   
-    &mdash; Documentation by YARD 0.9.7
+    &mdash; Documentation by YARD 0.9.8
   
 </title>
 
@@ -185,9 +185,9 @@ define selinux::restorecond::fragment (
 </div>
 
       <div id="footer">
-  Generated on Fri Jan 13 15:43:22 2017 by
+  Generated on Wed Jan 18 21:43:24 2017 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
-  0.9.7 (ruby-2.3.3).
+  0.9.8 (ruby-2.3.3).
 </div>
 
     </div>

--- a/docs/top-level-namespace.html
+++ b/docs/top-level-namespace.html
@@ -6,7 +6,7 @@
 <title>
   Top Level Namespace
   
-    &mdash; Documentation by YARD 0.9.7
+    &mdash; Documentation by YARD 0.9.8
   
 </title>
 
@@ -90,9 +90,9 @@
 </div>
 
       <div id="footer">
-  Generated on Fri Jan 13 15:43:22 2017 by
+  Generated on Wed Jan 18 21:43:24 2017 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
-  0.9.7 (ruby-2.3.3).
+  0.9.8 (ruby-2.3.3).
 </div>
 
     </div>

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "puppet-selinux",
-  "version": "0.8.1-rc0",
+  "version": "1.0.0",
   "author": "Vox Pupuli",
   "summary": "This class manages SELinux on RHEL based systems",
   "license": "Apache-2.0",


### PR DESCRIPTION
Successfully ran acceptance test for beaker sets:

* centos-72-x64
* centos-66-x64
* fedora-25-x64
* fedora-24-x64
    
Additionally successfully tested with centos/6 and centos/7
distribution upstream vagrant boxes and the same beaker test.
    
Closes #184 

Included commits since 0.8.0 release not directly in this PR:

510c303 (GH-148) Add spec tests for class parameters
de69bf8 Use correct type in create_resource with permissive parameter
b9041d2 (GH-148) Make use of class selinux parameters
a25d44d (GH-119) Don't accept udp6 and tcp6 as protocol name with selinux::port
5744329 Fix for Security/YAMLLoad rubocop warning
211de87 Adapt required rubocop config change
0467ea8 modulesync 0.19.0
0bf10cc Fix broken link to puppet strings documentation
699e6b2 Generated puppet strings docs
0f83a6f Provide resource ordering UML diagram
d12a836 Convert inline docs to puppet-strings format
c0f1168 Add redcarpet gem needed for puppet strings
65ecdde Generate puppet strings in docs/ folder
7fd977a Document known problems / limitations
c34f99c [blacksmith] Bump version to 0.8.1-rc0
3442761 modulesync 0.18.0
a304af6 bump required puppet version to 4.6.1
4f99a3d (GH-147) Test default resource ordering in acceptance test
b306f49 (GH-147) Add spec tests for the ordering of resources
8116a4f (GH-147) Add ordering of resources
