### PR TITLE
Refactor selinux::module

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,15 @@ running system.
 * Mailinglist: <voxpupuli@groups.io> 
   ([groups.io Webinterface](https://groups.io/g/voxpupuli/topics))
 
+## Upgrading from puppet-selinux 0.8.x
+
+* Previously, module building always used the refpolicy framework. The default
+  module builder is now 'simple', which uses only checkmodule. Not all features are
+  supported with this builder.
+
+  To build modules using the refpolicy framework like previous versions did,
+  specify the  'refpolicy' builder either explicitly per module or globally
+  via the main class
 
 ## Known problems / limitations
 
@@ -51,8 +60,6 @@ running system.
   does) the order is important. If you add /my/folder before /my/folder/subfolder
   only /my/folder will match (limitation of SELinux). There is no such limitation
   to file-contexts defined in SELinux modules. (GH-121)
-* `selinux::module` only allows to add a type enforcment file (`*.te`) but no
-  interfaces (`*.if`) or file-contexts (`*.fc`).
 * While SELinux is disabled the defined types `selinux::boolean`, 
   `selinux::fcontext`, `selinux::port` will produce puppet agent runtime errors 
   because the used tools fail.
@@ -97,12 +104,15 @@ are `target`, `minimum`, and `mls`). Note that disabling SELinux requires a rebo
 to fully take effect. It will run in `permissive` mode until then.
 
 
-### Deploy a custom module
+### Deploy a custom module using the refpolicy framework
 
 ```puppet
 selinux::module { 'resnet-puppet':
-  ensure => 'present',
-  source => 'puppet:///modules/site_puppet/site-puppet.te',
+  ensure    => 'present',
+  source_te => 'puppet:///modules/site_puppet/site-puppet.te',
+  source_fc => 'puppet:///modules/site_puppet/site-puppet.fc',
+  source_if => 'puppet:///modules/site_puppet/site-puppet.if',
+  builder   => 'refpolicy'
 }
 ```
 

--- a/files/selinux_build_module.sh
+++ b/files/selinux_build_module.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+module_name="$1"
+set -e
+checkmodule -M -m -o ${module_name}.mod ${module_name}.te
+package_args="-o ${module_name}.pp -m ${module_name}.mod"
+if [ -f "${module_name}.fc" ]; then
+    package_args="${package_args} --fc ${module_name}.fc"
+fi
+
+semodule_package ${package_args}

--- a/lib/facter/selinux_agent_vardir.rb
+++ b/lib/facter/selinux_agent_vardir.rb
@@ -1,0 +1,6 @@
+require 'puppet'
+Facter.add(:selinux_agent_vardir) do
+  setcode do
+    Puppet.settings['vardir']
+  end
+end

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -25,7 +25,7 @@
 # refpolicy module builder
 #   Default value: OS dependent (see params.pp)
 # @param default_builder which builder to use by default with selinux::module
-#   Default value: refpolicy
+#   Default value: simple
 # @param boolean Hash of selinux::boolean resource parameters
 # @param fcontext Hash of selinux::fcontext resource parameters
 # @param module Hash of selinux::module resource parameters

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -33,14 +33,14 @@
 # @param port Hash of selinux::port resource parameters
 #
 class selinux (
-  $mode                   = $::selinux::params::mode,
-  $type                   = $::selinux::params::type,
-  $refpolicy_makefile     = $::selinux::params::refpolicy_makefile,
-  $manage_package         = $::selinux::params::manage_package,
-  $package_name           = $::selinux::params::package_name,
-  $refpolicy_package_name = $::selinux::params::refpolicy_package_name,
-  $module_build_root      = $::selinux::params::module_build_root,
-  $default_builder        = 'simple',
+  Optional[Enum['enforcing', 'permissive', 'disabled']] $mode = $::selinux::params::mode,
+  Optional[Enum['targeted', 'minimum', 'mls']] $type          = $::selinux::params::type,
+  String  $refpolicy_makefile                                 = $::selinux::params::refpolicy_makefile,
+  Boolean $manage_package                                     = $::selinux::params::manage_package,
+  String $package_name                                        = $::selinux::params::package_name,
+  String $refpolicy_package_name                              = $::selinux::params::refpolicy_package_name,
+  String $module_build_root                                   = $::selinux::params::module_build_root,
+  Enum['refpolicy', 'simple'] $default_builder                = 'simple',
 
   ### START Hiera Lookups ###
   $boolean        = undef,
@@ -51,22 +51,6 @@ class selinux (
   ### END Hiera Lookups ###
 
 ) inherits selinux::params {
-
-  $mode_real = $mode ? {
-    /\w+/   => $mode,
-    default => 'undef',
-  }
-
-  $type_real = $type ? {
-    /\w+/   => $type,
-    default => 'undef',
-  }
-
-  validate_re($mode_real, ['^enforcing$', '^permissive$', '^disabled$', '^undef$'], "Valid modes are enforcing, permissive, and disabled.  Received: ${mode}")
-  validate_re($type_real, ['^targeted$', '^minimum$', '^mls$', '^undef$'], "Valid types are targeted, minimum, and mls.  Received: ${type}")
-  validate_string($refpolicy_makefile)
-  validate_bool($manage_package)
-  validate_string($package_name)
 
   class { '::selinux::package':
     manage_package => $manage_package,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -14,7 +14,7 @@
 # @param type sets the selinux type
 #   Default value: undef
 #   Allowed values: (targeted|minimum|mls|undef)
-# @param makefile the path to the system's SELinux makefile
+# @param refpolicy_makefile the path to the system's SELinux makefile for the refpolicy framework
 #   Default value: /usr/share/selinux/devel/Makefile
 #   Allowed value: absolute path
 # @param manage_package manage the package for selinux tools and refpolicy
@@ -35,7 +35,7 @@
 class selinux (
   $mode                   = $::selinux::params::mode,
   $type                   = $::selinux::params::type,
-  $makefile               = $::selinux::params::refpolicy_makefile,
+  $refpolicy_makefile     = $::selinux::params::refpolicy_makefile,
   $manage_package         = $::selinux::params::manage_package,
   $package_name           = $::selinux::params::package_name,
   $refpolicy_package_name = $::selinux::params::refpolicy_package_name,
@@ -64,7 +64,7 @@ class selinux (
 
   validate_re($mode_real, ['^enforcing$', '^permissive$', '^disabled$', '^undef$'], "Valid modes are enforcing, permissive, and disabled.  Received: ${mode}")
   validate_re($type_real, ['^targeted$', '^minimum$', '^mls$', '^undef$'], "Valid types are targeted, minimum, and mls.  Received: ${type}")
-  validate_string($makefile)
+  validate_string($refpolicy_makefile)
   validate_bool($manage_package)
   validate_string($package_name)
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -14,16 +14,18 @@
 # @param type sets the selinux type
 #   Default value: undef
 #   Allowed values: (targeted|minimum|mls|undef)
-# @param sx_mod_dir directory where to store puppet managed selinux modules
-#   Default value: /usr/share/selinux
-#   Allowed values: absolute path
-# @param makefile the path to the systems SELinux makefile
+# @param makefile the path to the system's SELinux makefile
 #   Default value: /usr/share/selinux/devel/Makefile
 #   Allowed value: absolute path
-# @param manage_package manage the package for selinux tools
+# @param manage_package manage the package for selinux tools and refpolicy
 #   Default value: true
 # @param package_name sets the name for the selinux tools package
 #   Default value: OS dependent (see params.pp)
+# @param refpolicy_package_name sets the name for the refpolicy development package, required for the
+# refpolicy module builder
+#   Default value: OS dependent (see params.pp)
+# @param default_builder which builder to use by default with selinux::module
+#   Default value: refpolicy
 # @param boolean Hash of selinux::boolean resource parameters
 # @param fcontext Hash of selinux::fcontext resource parameters
 # @param module Hash of selinux::module resource parameters
@@ -31,12 +33,14 @@
 # @param port Hash of selinux::port resource parameters
 #
 class selinux (
-  $mode           = $::selinux::params::mode,
-  $type           = $::selinux::params::type,
-  $sx_mod_dir     = $::selinux::params::sx_mod_dir,
-  $makefile       = $::selinux::params::makefile,
-  $manage_package = $::selinux::params::manage_package,
-  $package_name   = $::selinux::params::package_name,
+  $mode                   = $::selinux::params::mode,
+  $type                   = $::selinux::params::type,
+  $makefile               = $::selinux::params::refpolicy_makefile,
+  $manage_package         = $::selinux::params::manage_package,
+  $package_name           = $::selinux::params::package_name,
+  $refpolicy_package_name = $::selinux::params::refpolicy_package_name,
+  $module_build_root      = $::selinux::params::module_build_root,
+  $default_builder        = 'simple',
 
   ### START Hiera Lookups ###
   $boolean        = undef,
@@ -58,7 +62,6 @@ class selinux (
     default => 'undef',
   }
 
-  validate_absolute_path($sx_mod_dir)
   validate_re($mode_real, ['^enforcing$', '^permissive$', '^disabled$', '^undef$'], "Valid modes are enforcing, permissive, and disabled.  Received: ${mode}")
   validate_re($type_real, ['^targeted$', '^minimum$', '^mls$', '^undef$'], "Valid types are targeted, minimum, and mls.  Received: ${type}")
   validate_string($makefile)

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -47,7 +47,7 @@ class selinux::params {
           case $os_maj_release {
             '7': {
               $sx_fs_mount = '/sys/fs/selinux'
-              $package_name = 'selinux-policy-devel'
+              $package_name = 'policycoreutils-python'
             }
             '6': {
               $sx_fs_mount = '/selinux'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -6,11 +6,15 @@
 # This class provides default parameters for the selinux class
 #
 class selinux::params {
-  $makefile       = '/usr/share/selinux/devel/Makefile'
-  $sx_mod_dir     = '/usr/share/selinux'
+  $refpolicy_makefile = '/usr/share/selinux/devel/Makefile'
   $mode           = undef
   $type           = undef
   $manage_package = true
+
+  $refpolicy_package_name = 'selinux-policy-devel'
+
+  validate_absolute_path($::selinux_agent_vardir)
+  $module_build_root = "${::selinux_agent_vardir}/puppet-selinux"
 
   if $::operatingsystemmajrelease {
     $os_maj_release = $::operatingsystemmajrelease

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -36,7 +36,7 @@ class selinux::params {
               $package_name = 'policycoreutils-devel'
             }
             '24', '25' : {
-              $package_name = 'selinux-policy-devel'
+              $package_name = 'policycoreutils-python-utils'
             }
             default: {
               fail("${::operatingsystem}-${::os_maj_release} is not supported")

--- a/manifests/refpolicy_package.pp
+++ b/manifests/refpolicy_package.pp
@@ -1,0 +1,21 @@
+# selinux::package
+#
+# THIS IS A PRIVATE CLASS
+# =======================
+#
+# This module manages additional packages required to support some of the functions.
+#
+# @param manage_package See main class
+# @param package_name See main class
+#
+class selinux::refpolicy_package (
+  $manage_package = $::selinux::manage_package,
+  $package_name   = $::selinux::refpolicy_package_name,
+) inherits ::selinux {
+  if $caller_module_name != $module_name {
+    fail("Use of private class ${name} by ${caller_module_name}")
+  }
+  if $manage_package {
+    ensure_packages ($package_name)
+  }
+}

--- a/spec/acceptance/class_spec.rb
+++ b/spec/acceptance/class_spec.rb
@@ -19,27 +19,27 @@ describe 'selinux class' do
       file {'/tmp/selinux_simple_policy.te':
         ensure  => 'file',
         content => @("EOF")
-        module puppet_selinux_simple_policy 1.0;
-        require {
-            type httpd_log_t;
-            type postfix_postdrop_t;
-            class dir getattr;
-            class file { read getattr };
-        }
-        allow postfix_postdrop_t httpd_log_t:file getattr;
+          module puppet_selinux_simple_policy 1.0;
+          require {
+              type httpd_log_t;
+              type postfix_postdrop_t;
+              class dir getattr;
+              class file { read getattr };
+          }
+          allow postfix_postdrop_t httpd_log_t:file getattr;
         | EOF
       }
 
       file {'/tmp/selinux_test_policy.te':
         ensure  => 'file',
         content => @("EOF")
-        policy_module(puppet_selinux_test_policy, 1.0.0)
-        gen_tunable(puppet_selinux_test_policy_bool, false)
-        type puppet_selinux_test_policy_t;
-        type puppet_selinux_test_policy_exec_t;
-        init_daemon_domain(puppet_selinux_test_policy_t, puppet_selinux_test_policy_exec_t)
-        type puppet_selinux_test_policy_port_t;
-        corenet_port(puppet_selinux_test_policy_port_t)
+          policy_module(puppet_selinux_test_policy, 1.0.0)
+          gen_tunable(puppet_selinux_test_policy_bool, false)
+          type puppet_selinux_test_policy_t;
+          type puppet_selinux_test_policy_exec_t;
+          init_daemon_domain(puppet_selinux_test_policy_t, puppet_selinux_test_policy_exec_t)
+          type puppet_selinux_test_policy_port_t;
+          corenet_port(puppet_selinux_test_policy_port_t)
         | EOF
       }
 

--- a/spec/acceptance/class_spec.rb
+++ b/spec/acceptance/class_spec.rb
@@ -15,12 +15,44 @@ describe 'selinux class' do
         protocol => 'tcp',
       }
 
-      # with puppet4 I would use a HERE DOC to make this pretty,
-      # but with puppet3 it's not possible.
+      # just something simple I found via Google:
+      file {'/tmp/selinux_simple_policy.te':
+        ensure  => 'file',
+        content => @("EOF")
+        module puppet_selinux_simple_policy 1.0;
+        require {
+            type httpd_log_t;
+            type postfix_postdrop_t;
+            class dir getattr;
+            class file { read getattr };
+        }
+        allow postfix_postdrop_t httpd_log_t:file getattr;
+        | EOF
+      }
+
+      file {'/tmp/selinux_test_policy.te':
+        ensure  => 'file',
+        content => @("EOF")
+        policy_module(puppet_selinux_test_policy, 1.0.0)
+        gen_tunable(puppet_selinux_test_policy_bool, false)
+        type puppet_selinux_test_policy_t;
+        type puppet_selinux_test_policy_exec_t;
+        init_daemon_domain(puppet_selinux_test_policy_t, puppet_selinux_test_policy_exec_t)
+        type puppet_selinux_test_policy_port_t;
+        corenet_port(puppet_selinux_test_policy_port_t)
+        | EOF
+      }
+
+      selinux::module { 'puppet_selinux_simple_policy':
+        source_te => 'file:///tmp/selinux_simple_policy.te',
+        builder   => 'simple',
+        require   => File['/tmp/selinux_simple_policy.te']
+      }
+
       selinux::module { 'puppet_selinux_test_policy':
-        content => "policy_module(puppet_selinux_test_policy, 1.0.0)\ngen_tunable(puppet_selinux_test_policy_bool, false)\ntype puppet_selinux_test_policy_t;\ntype puppet_selinux_test_policy_exec_t;\ninit_daemon_domain(puppet_selinux_test_policy_t, puppet_selinux_test_policy_exec_t)\ntype puppet_selinux_test_policy_port_t;\ncorenet_port(puppet_selinux_test_policy_port_t)\n",
-        prefix => '',
-        syncversion => undef,
+        source_te   => 'file:///tmp/selinux_test_policy.te',
+        builder     => 'refpolicy',
+        require     => File['/tmp/selinux_test_policy.te']
       }
 
       Class['selinux'] ->
@@ -76,13 +108,12 @@ describe 'selinux class' do
     its(:stdout) { is_expected.to match(%r{^Enforcing$}) }
   end
 
-  context 'the test module source should exist and the module should be loaded' do
-    describe file('/usr/share/selinux/puppet_selinux_test_policy.te') do
-      it { is_expected.to be_file }
-    end
-
+  context 'the compiled modules should be loaded' do
     describe command('semodule -l | grep puppet_selinux_test_policy') do
       its(:stdout) { is_expected.to match(%r{puppet_selinux_test_policy}) }
+    end
+    describe command('semodule -l | grep puppet_selinux_simple_policy') do
+      its(:stdout) { is_expected.to match(%r{puppet_selinux_simple_policy}) }
     end
   end
 

--- a/spec/classes/selinux_config_mode_spec.rb
+++ b/spec/classes/selinux_config_mode_spec.rb
@@ -15,7 +15,7 @@ describe 'selinux' do
       context 'config' do
         context 'invalid mode' do
           let(:params) { { mode: 'invalid' } }
-          it { expect { is_expected.to create_class('selinux') }.to raise_error(%r{Valid modes are enforcing, permissive, and disabled.  Received: invalid}) }
+          it { expect { is_expected.to create_class('selinux') }.to raise_error(Puppet::Error, %r{Enum}) }
         end
 
         context 'undef mode' do

--- a/spec/classes/selinux_config_mode_spec.rb
+++ b/spec/classes/selinux_config_mode_spec.rb
@@ -19,10 +19,10 @@ describe 'selinux' do
         end
 
         context 'undef mode' do
-          it { is_expected.to have_file_resource_count(1) }
+          it { is_expected.to have_file_resource_count(3) }
           it { is_expected.to have_file_line_resource_count(0) }
           it { is_expected.to have_exec_resource_count(0) }
-          it { is_expected.to contain_file('/usr/share/selinux') }
+          it { is_expected.to contain_file('/var/lib/puppet/puppet-selinux') }
           it { is_expected.not_to contain_file_line('set-selinux-config-to-enforcing') }
           it { is_expected.not_to contain_file_line('set-selinux-config-to-permissive') }
           it { is_expected.not_to contain_file_line('set-selinux-config-to-disabled') }
@@ -35,7 +35,7 @@ describe 'selinux' do
         context 'enforcing' do
           let(:params) { { mode: 'enforcing' } }
 
-          it { is_expected.to contain_file('/usr/share/selinux').with(ensure: 'directory') }
+          it { is_expected.to contain_file('/var/lib/puppet/puppet-selinux') }
           it { is_expected.to contain_file_line('set-selinux-config-to-enforcing').with(line: 'SELINUX=enforcing') }
           it { is_expected.to contain_exec('change-selinux-status-to-enforcing').with(command: 'setenforce 1') }
           it { is_expected.not_to contain_file('/.autorelabel') }
@@ -43,7 +43,7 @@ describe 'selinux' do
 
         context 'permissive' do
           let(:params) { { mode: 'permissive' } }
-          it { is_expected.to contain_file('/usr/share/selinux').with(ensure: 'directory') }
+          it { is_expected.to contain_file('/var/lib/puppet/puppet-selinux') }
           it { is_expected.to contain_file_line('set-selinux-config-to-permissive').with(line: 'SELINUX=permissive') }
           it { is_expected.to contain_exec('change-selinux-status-to-permissive').with(command: 'setenforce 0') }
           it { is_expected.not_to contain_file('/.autorelabel') }
@@ -51,7 +51,7 @@ describe 'selinux' do
 
         context 'disabled' do
           let(:params) { { mode: 'disabled' } }
-          it { is_expected.to contain_file('/usr/share/selinux').with(ensure: 'directory') }
+          it { is_expected.to contain_file('/var/lib/puppet/puppet-selinux') }
           it { is_expected.to contain_file_line('set-selinux-config-to-disabled').with(line: 'SELINUX=disabled') }
           it { is_expected.to contain_exec('change-selinux-status-to-disabled').with(command: 'setenforce 0') }
           it { is_expected.not_to contain_file('/.autorelabel') }

--- a/spec/classes/selinux_config_type_spec.rb
+++ b/spec/classes/selinux_config_type_spec.rb
@@ -12,10 +12,12 @@ describe 'selinux' do
           it { expect { is_expected.to create_class('selinux') }.to raise_error(%r{Valid types are targeted, minimum, and mls.  Received: invalid}) }
         end
         context 'undef type' do
-          it { is_expected.to have_file_resource_count(1) }
+          it { is_expected.to have_file_resource_count(3) }
           it { is_expected.to have_file_line_resource_count(0) }
           it { is_expected.to have_exec_resource_count(0) }
-          it { is_expected.to contain_file('/usr/share/selinux') }
+          it { is_expected.to contain_file('/var/lib/puppet/puppet-selinux') }
+          it { is_expected.to contain_file('/var/lib/puppet/puppet-selinux/modules') }
+          it { is_expected.to contain_file('/var/lib/puppet/puppet-selinux/modules/selinux_build_module.sh') }
           it { is_expected.not_to contain_file_line('set-selinux-config-type-to-targeted') }
           it { is_expected.not_to contain_file_line('set-selinux-config-type-to-minimum') }
           it { is_expected.not_to contain_file_line('set-selinux-config-type-to-mls') }
@@ -23,20 +25,26 @@ describe 'selinux' do
         context 'targeted' do
           let(:params) { { type: 'targeted' } }
 
-          it { is_expected.to contain_file('/usr/share/selinux').with(ensure: 'directory') }
+          it { is_expected.to contain_file('/var/lib/puppet/puppet-selinux') }
+          it { is_expected.to contain_file('/var/lib/puppet/puppet-selinux/modules') }
+          it { is_expected.to contain_file('/var/lib/puppet/puppet-selinux/modules/selinux_build_module.sh') }
           it { is_expected.to contain_file_line('set-selinux-config-type-to-targeted').with(line: 'SELINUXTYPE=targeted') }
         end
         context 'minimum' do
           let(:params) { { type: 'minimum' } }
 
-          it { is_expected.to contain_file('/usr/share/selinux').with(ensure: 'directory') }
+          it { is_expected.to contain_file('/var/lib/puppet/puppet-selinux') }
+          it { is_expected.to contain_file('/var/lib/puppet/puppet-selinux/modules') }
+          it { is_expected.to contain_file('/var/lib/puppet/puppet-selinux/modules/selinux_build_module.sh') }
           it { is_expected.to contain_file_line('set-selinux-config-type-to-minimum').with(line: 'SELINUXTYPE=minimum') }
         end
 
         context 'mls' do
           let(:params) { { type: 'mls' } }
 
-          it { is_expected.to contain_file('/usr/share/selinux').with(ensure: 'directory') }
+          it { is_expected.to contain_file('/var/lib/puppet/puppet-selinux') }
+          it { is_expected.to contain_file('/var/lib/puppet/puppet-selinux/modules') }
+          it { is_expected.to contain_file('/var/lib/puppet/puppet-selinux/modules/selinux_build_module.sh') }
           it { is_expected.to contain_file_line('set-selinux-config-type-to-mls').with(line: 'SELINUXTYPE=mls') }
         end
       end

--- a/spec/classes/selinux_config_type_spec.rb
+++ b/spec/classes/selinux_config_type_spec.rb
@@ -9,7 +9,7 @@ describe 'selinux' do
       context 'config' do
         context 'invalid type' do
           let(:params) { { type: 'invalid' } }
-          it { expect { is_expected.to create_class('selinux') }.to raise_error(%r{Valid types are targeted, minimum, and mls.  Received: invalid}) }
+          it { expect { is_expected.to create_class('selinux') }.to raise_error(Puppet::Error, %r{Enum}) }
         end
         context 'undef type' do
           it { is_expected.to have_file_resource_count(3) }

--- a/spec/classes/selinux_package_spec.rb
+++ b/spec/classes/selinux_package_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe 'selinux' do
   context 'package' do
-    %w(6).each do |majrelease|
+    %w(6 7).each do |majrelease|
       context "On RedHat #{majrelease} based OSes" do
         let(:facts) do
           {
@@ -17,21 +17,6 @@ describe 'selinux' do
       end
     end
 
-    %w(7).each do |majrelease|
-      context "On RedHat #{majrelease} based OSes" do
-        let(:facts) do
-          {
-            osfamily: 'RedHat',
-            operatingsystem: 'RedHat',
-            operatingsystemmajrelease: majrelease,
-            selinux_current_mode: 'enforcing'
-          }
-        end
-
-        it { is_expected.to contain_package('selinux-policy-devel').with(ensure: 'present') }
-      end
-    end
-
     %w(24 25).each do |majrelease|
       context "On Fedora #{majrelease}" do
         let(:facts) do
@@ -42,7 +27,7 @@ describe 'selinux' do
             selinux_current_mode: 'enforcing'
           }
         end
-        it { is_expected.to contain_package('selinux-policy-devel').with(ensure: 'present') }
+        it { is_expected.to contain_package('policycoreutils-python-utils').with(ensure: 'present') }
       end
     end
 
@@ -60,7 +45,7 @@ describe 'selinux' do
         }
       end
 
-      it { is_expected.not_to contain_package('policycoreutils').with(ensure: 'present') }
+      it { is_expected.not_to contain_package('policycoreutils-python').with(ensure: 'present') }
     end
 
     context 'install a different package name' do

--- a/spec/classes/selinux_spec.rb
+++ b/spec/classes/selinux_spec.rb
@@ -25,8 +25,8 @@ describe 'selinux' do
         let(:params) do
           {
             module: {
-              'mymodule1' =>  { 'content' => 'dummy' },
-              'mymodule2' =>  { 'content' => 'dummy' }
+              'mymodule1' =>  { 'source_te' => 'dummy' },
+              'mymodule2' =>  { 'source_te' => 'dummy' }
             }
           }
         end

--- a/spec/default_module_facts.yml
+++ b/spec/default_module_facts.yml
@@ -5,3 +5,5 @@ operatingsystemmajrelease: '7'
 # concat facts
 id: 0
 path: /tmp
+# custom fact for module building:
+selinux_agent_vardir: /var/lib/puppet

--- a/spec/defines/selinux_module_spec.rb
+++ b/spec/defines/selinux_module_spec.rb
@@ -8,46 +8,102 @@ describe 'selinux::module' do
       let(:facts) do
         facts
       end
+      let(:workdir) do
+        '/var/lib/puppet/puppet-selinux/modules/mymodule'
+      end
 
       context 'ordering' do
         let(:params) do
           {
-            source: 'puppet:///modules/mymodule/selinux/mymodule.te'
+            source_te: 'puppet:///modules/mymodule/selinux/mymodule.te'
           }
         end
         it { is_expected.to contain_selinux__module('mymodule').that_requires('Anchor[selinux::module pre]') }
         it { is_expected.to contain_selinux__module('mymodule').that_comes_before('Anchor[selinux::module post]') }
       end
 
-      context 'present case' do
+      context 'present case with refpolicy' do
         let(:params) do
           {
-            source: 'puppet:///modules/mymodule/selinux/mymodule.te'
+            source_te: 'puppet:///modules/mymodule/selinux/mymodule.te',
+            builder: 'refpolicy'
+          }
+        end
+
+        it { is_expected.to contain_file(workdir) }
+        it { is_expected.to contain_file("#{workdir}/mymodule.te").that_notifies('Exec[clean-module-mymodule]') }
+        it { is_expected.to contain_exec('clean-module-mymodule').with(command: "rm -f 'mymodule.pp' loaded", cwd: workdir) }
+        it { is_expected.to contain_exec('build-module-mymodule').with(command: 'make -f /usr/share/selinux/devel/Makefile mymodule.pp || (rm -f mymodule.pp loaded && exit 1)', creates: "#{workdir}/mymodule.pp") }
+        it { is_expected.to contain_exec('install-module-mymodule').with(command: 'semodule -i mymodule.pp && touch loaded', cwd: workdir, creates: "#{workdir}/loaded") }
+        it { is_expected.to contain_selmodule('mymodule').with_ensure('present', selmodulepath: "#{workdir}/module.pp") }
+      end
+
+      context 'present case with refpolicy' do
+        let(:params) do
+          {
+            source_if: 'puppet:///modules/mymodule/selinux/mymodule.if',
+            source_fc: 'puppet:///modules/mymodule/selinux/mymodule.fc',
+            builder: 'refpolicy'
+          }
+        end
+
+        it { is_expected.to contain_file(workdir) }
+        it { is_expected.to contain_file("#{workdir}/mymodule.if").that_notifies('Exec[clean-module-mymodule]') }
+        it { is_expected.to contain_file("#{workdir}/mymodule.fc").that_notifies('Exec[clean-module-mymodule]') }
+        it { is_expected.to contain_exec('clean-module-mymodule').with(command: "rm -f 'mymodule.pp' loaded", cwd: workdir) }
+        it { is_expected.to contain_exec('build-module-mymodule').with(command: 'make -f /usr/share/selinux/devel/Makefile mymodule.pp || (rm -f mymodule.pp loaded && exit 1)', creates: "#{workdir}/mymodule.pp") }
+        it { is_expected.to contain_exec('install-module-mymodule').with(command: 'semodule -i mymodule.pp && touch loaded', cwd: workdir, creates: "#{workdir}/loaded") }
+        it { is_expected.to contain_selmodule('mymodule').with_ensure('present', selmodulepath: "#{workdir}/module.pp") }
+      end
+
+      context 'present case with refpolicy' do
+        let(:params) do
+          {
+            source_te: 'puppet:///modules/mymodule/selinux/mymodule.te',
+            source_if: 'puppet:///modules/mymodule/selinux/mymodule.if',
+            source_fc: 'puppet:///modules/mymodule/selinux/mymodule.fc',
+            builder: 'refpolicy'
+          }
+        end
+
+        it { is_expected.to contain_file(workdir) }
+        it { is_expected.to contain_file("#{workdir}/mymodule.te").that_notifies('Exec[clean-module-mymodule]') }
+        it { is_expected.to contain_file("#{workdir}/mymodule.if").that_notifies('Exec[clean-module-mymodule]') }
+        it { is_expected.to contain_file("#{workdir}/mymodule.fc").that_notifies('Exec[clean-module-mymodule]') }
+        it { is_expected.to contain_exec('clean-module-mymodule').with(command: "rm -f 'mymodule.pp' loaded", cwd: workdir) }
+        it { is_expected.to contain_exec('build-module-mymodule').with(command: 'make -f /usr/share/selinux/devel/Makefile mymodule.pp || (rm -f mymodule.pp loaded && exit 1)', creates: "#{workdir}/mymodule.pp") }
+        it { is_expected.to contain_exec('install-module-mymodule').with(command: 'semodule -i mymodule.pp && touch loaded', cwd: workdir, creates: "#{workdir}/loaded") }
+        it { is_expected.to contain_selmodule('mymodule').with_ensure('present', selmodulepath: "#{workdir}/module.pp") }
+      end
+
+      context 'present case with simple builder' do
+        let(:params) do
+          {
+            source_te: 'puppet:///modules/mymodule/selinux/mymodule.te',
+            builder: 'simple'
+          }
+        end
+
+        it { is_expected.to contain_file(workdir) }
+        it { is_expected.to contain_file("#{workdir}/mymodule.te").that_notifies('Exec[clean-module-mymodule]') }
+        it { is_expected.to contain_exec('clean-module-mymodule').with(command: "rm -f 'mymodule.pp' loaded", cwd: workdir) }
+        it { is_expected.to contain_exec('build-module-mymodule').with(command: '/var/lib/puppet/puppet-selinux/modules/selinux_build_module.sh mymodule || (rm -f mymodule.pp loaded && exit 1)', creates: "#{workdir}/mymodule.pp") }
+        it { is_expected.to contain_exec('install-module-mymodule').with(command: 'semodule -i mymodule.pp && touch loaded', cwd: workdir, creates: "#{workdir}/loaded") }
+        it { is_expected.to contain_selmodule('mymodule').with_ensure('present', selmodulepath: "#{workdir}/module.pp") }
+      end
+
+      context 'unsupported source with simple builder' do
+        let(:params) do
+          {
+            source_if: 'puppet:///modules/mymodule/selinux/mymodule.te',
+            builder: 'simple'
           }
         end
 
         it do
-          is_expected.to contain_file('/usr/share/selinux/mymodule.te').that_notifies('Exec[/usr/share/selinux/mymodule.pp]')
-          is_expected.to contain_exec('/usr/share/selinux/mymodule.pp').with(command: 'make -f /usr/share/selinux/devel/Makefile mymodule.pp')
-          is_expected.to contain_selmodule('mymodule').with_ensure('present')
+          is_expected.to raise_error(Puppet::Error, %r{simple builder does not support})
         end
       end
-
-      context 'present case and prefix set' do
-        let(:params) do
-          {
-            source: 'puppet:///modules/mymodule/selinux/mymodule.te',
-            prefix: 'local_'
-          }
-        end
-
-        it do
-          is_expected.to contain_file('/usr/share/selinux/local_mymodule.te').that_notifies('Exec[/usr/share/selinux/local_mymodule.pp]')
-          is_expected.to contain_exec('/usr/share/selinux/local_mymodule.pp').with(command: 'make -f /usr/share/selinux/devel/Makefile local_mymodule.pp')
-          is_expected.to contain_selmodule('mymodule').with_ensure('present')
-        end
-      end
-
       context 'absent case' do
         let(:params) do
           {
@@ -55,9 +111,8 @@ describe 'selinux::module' do
           }
         end
 
-        it do
-          is_expected.to contain_selmodule('mymodule').with_ensure('absent')
-        end
+        it { is_expected.to contain_selmodule('mymodule').with_ensure('absent') }
+        it { is_expected.not_to contain_file(workdir) }
       end
     end
   end


### PR DESCRIPTION
I thought I'd actually implement part of what's being discussed in #178 

This doesn't yet support building the things without selinux-devel,
but it does work, and handles failures gracefully.

It doesn't look like module building needs its own provider, but behaviour on RHEL5/6 should be tested.