### PR TITLE
Fix puppet strings warnings and minor README.md update

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ This class manages SELinux on RHEL based systems.
 
 ## Requirements
 
-* Puppet 3.8.7 or later
+* Puppet 4 or later
 
 ## Module Description
 
@@ -128,6 +128,14 @@ selinux::boolean { 'puppetagent_manage_all_files': }
     * `semanage` requires `--noreload` while in disabled mode when
       adding or changing something
     * Only few `--list` operations work
+* run acceptance tests:
+
+```
+BEAKER_debug=yes BEAKER_set="centos-6-x64" PUPPET_INSTALL_TYPE="agent" bundle exec rake beaker
+BEAKER_debug=yes BEAKER_set="centos-7-x64" PUPPET_INSTALL_TYPE="agent" bundle exec rake beaker
+BEAKER_debug=yes BEAKER_set="fedora-24-x64" PUPPET_INSTALL_TYPE="agent" bundle exec rake beaker
+BEAKER_debug=yes BEAKER_set="fedora-25-x64" PUPPET_INSTALL_TYPE="agent" bundle exec rake beaker
+```
 
 ### Facter facts
 

--- a/docs/_index.html
+++ b/docs/_index.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>
-  Documentation by YARD 0.9.7
+  Documentation by YARD 0.9.8
   
 </title>
 
@@ -52,7 +52,7 @@
         <div class="clear"></div>
       </div>
 
-      <div id="content"><h1 class="noborder title">Documentation by YARD 0.9.7</h1>
+      <div id="content"><h1 class="noborder title">Documentation by YARD 0.9.8</h1>
 <div id="listing">
   <h1 class="alphaindex">Alphabetic Index</h1>
   
@@ -134,6 +134,11 @@
             </li>
     
             <li>
+      <span class='object_link'><a href="puppet_defined_types/selinux_3A_3Afcontext_3A_3Aequivalence.html" title="puppet_defined_types::selinux::fcontext::equivalence (puppet_defined_type)">selinux::fcontext::equivalence</a></span>
+      
+            </li>
+    
+            <li>
       <span class='object_link'><a href="puppet_defined_types/selinux_3A_3Amodule.html" title="puppet_defined_types::selinux::module (puppet_defined_type)">selinux::module</a></span>
       
             </li>
@@ -161,6 +166,92 @@
 </table>
 
 
+<h2>Resource Type Listing A-Z</h2>
+
+  
+<table>
+  <tr>
+    <td valign='top' width="33%">
+  
+    
+      <ul id="alpha_S" class="alpha">
+        <li class="letter">S</li>
+          <ul>
+    
+            <li>
+      <span class='object_link'><a href="puppet_types/selinux_fcontext.html" title="puppet_types::selinux_fcontext (puppet_type)">selinux_fcontext</a></span>
+      
+            </li>
+    
+            <li>
+      <span class='object_link'><a href="puppet_types/selinux_fcontext_equivalence.html" title="puppet_types::selinux_fcontext_equivalence (puppet_type)">selinux_fcontext_equivalence</a></span>
+      
+            </li>
+    
+            <li>
+      <span class='object_link'><a href="puppet_types/selinux_permissive.html" title="puppet_types::selinux_permissive (puppet_type)">selinux_permissive</a></span>
+      
+            </li>
+    
+            <li>
+      <span class='object_link'><a href="puppet_types/selinux_port.html" title="puppet_types::selinux_port (puppet_type)">selinux_port</a></span>
+      
+            </li>
+    
+      </ul>
+    </ul>
+  
+    </td>
+  </tr>
+</table>
+
+
+<h2>Puppet Provider Listing A-Z</h2>
+
+  
+<table>
+  <tr>
+    <td valign='top' width="33%">
+  
+    
+      <ul id="alpha_S" class="alpha">
+        <li class="letter">S</li>
+          <ul>
+    
+            <li>
+      <span class='object_link'><a href="puppet_providers_selinux_port/semanage.html" title="puppet_providers_selinux_port::semanage (puppet_provider)">semanage</a></span>
+      
+              <small>(Resource type: selinux_port)</small>
+      
+            </li>
+    
+            <li>
+      <span class='object_link'><a href="puppet_providers_selinux_fcontext/semanage.html" title="puppet_providers_selinux_fcontext::semanage (puppet_provider)">semanage</a></span>
+      
+              <small>(Resource type: selinux_fcontext)</small>
+      
+            </li>
+    
+            <li>
+      <span class='object_link'><a href="puppet_providers_selinux_permissive/semanage.html" title="puppet_providers_selinux_permissive::semanage (puppet_provider)">semanage</a></span>
+      
+              <small>(Resource type: selinux_permissive)</small>
+      
+            </li>
+    
+            <li>
+      <span class='object_link'><a href="puppet_providers_selinux_fcontext_equivalence/semanage.html" title="puppet_providers_selinux_fcontext_equivalence::semanage (puppet_provider)">semanage</a></span>
+      
+              <small>(Resource type: selinux_fcontext_equivalence)</small>
+      
+            </li>
+    
+      </ul>
+    </ul>
+  
+    </td>
+  </tr>
+</table>
 
 
 
@@ -181,9 +272,9 @@
 </div>
 
       <div id="footer">
-  Generated on Fri Jan 13 15:43:22 2017 by
+  Generated on Tue Jan 31 20:51:44 2017 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
-  0.9.7 (ruby-2.3.3).
+  0.9.8 (ruby-2.3.3).
 </div>
 
     </div>

--- a/docs/file.README.html
+++ b/docs/file.README.html
@@ -6,7 +6,7 @@
 <title>
   File: README
   
-    &mdash; Documentation by YARD 0.9.7
+    &mdash; Documentation by YARD 0.9.8
   
 </title>
 
@@ -85,7 +85,7 @@
 <h2>Requirements</h2>
 
 <ul>
-<li>Puppet 3.8.7 or later</li>
+<li>Puppet 4 or later</li>
 </ul>
 
 <h2>Module Description</h2>
@@ -108,7 +108,11 @@ running system.</p>
 <li>If SELinux is disabled and you want to switch to permissive or enforcing you
 are required to reboot the system (limitation of SELinux). The module won&#39;t
 do this for you.</li>
-<li>If you add filecontexts with <code>semange fcontext</code> (what <code>selinux::fcontext</code> 
+<li>If SELinux is disabled and the user wants enforcing mode, the module
+will downgrade to permissive mode instead to avoid transitioning directly from
+disabled to enforcing state after a reboot and potentially breaking the system.
+The user will receive a warning when this happens,</li>
+<li>If you add filecontexts with <code>semanage fcontext</code> (what <code>selinux::fcontext</code>
 does) the order is important. If you add /my/folder before /my/folder/subfolder
 only /my/folder will match (limitation of SELinux). There is no such limitation
 to file-contexts defined in SELinux modules. (GH-121)</li>
@@ -117,19 +121,21 @@ interfaces (<code>*.if</code>) or file-contexts (<code>*.fc</code>).</li>
 <li>While SELinux is disabled the defined types <code>selinux::boolean</code>, 
 <code>selinux::fcontext</code>, <code>selinux::port</code> will produce puppet agent runtime errors 
 because the used tools fail.</li>
-<li><code>selinux::port</code> has the <code>action</code> parameter which  if you specify <code>-d</code> or 
-<code>--delete</code> silently does nothing. (GH-164)</li>
-<li><code>selinux::permissive</code> allows only to set a domain to permissive but not to
-remove it. (GH-165)</li>
+<li>If you try to remove a built-in permissive type, the operation will appear to succeed
+but will actually have no effect, making your puppet runs non-idempotent.</li>
+<li>The <code>selinux_port</code> provider may misbehave if the title does not correspond to
+the format it expects. Users should use the <code>selinux::port</code> define instead except
+when purging resources</li>
+<li>Defining port ranges that overlap with existing ranges is currently not detected, and will
+cause semanage to error when the resource is applied.</li>
 </ul>
 
 <h2>Usage</h2>
 
-<p>There is puppet-strings generated documentation available in the docs/ folder 
-of the github repo.</p>
+<p>Generated puppet strings documentation with examples is available from
+<a href="https://voxpupuli.org/puppet-selinux/">https://voxpupuli.org/puppet-selinux/</a></p>
 
-<p>It will be available at <a href="http://voxpupuli.org/pupppet-selinux">http://voxpupuli.org/pupppet-selinux</a> some time in 
-the future.</p>
+<p>It&#39;s also included in the docs/ folder as simple html pages.</p>
 
 <h2>Reference</h2>
 
@@ -189,7 +195,14 @@ to fully take effect. It will run in <code>permissive</code> mode until then.</p
 adding or changing something</li>
 <li>Only few <code>--list</code> operations work</li>
 </ul></li>
+<li>run acceptance tests:</li>
 </ul>
+
+<pre class="code ruby"><code class="ruby">BEAKER_debug=yes BEAKER_set=&quot;centos-6-x64&quot; PUPPET_INSTALL_TYPE=&quot;agent&quot; be rake beaker
+BEAKER_debug=yes BEAKER_set=&quot;centos-7-x64&quot; PUPPET_INSTALL_TYPE=&quot;agent&quot; be rake beaker
+BEAKER_debug=yes BEAKER_set=&quot;fedora-24-x64&quot; PUPPET_INSTALL_TYPE=&quot;agent&quot; be rake beaker
+BEAKER_debug=yes BEAKER_set=&quot;fedora-25-x64&quot; PUPPET_INSTALL_TYPE=&quot;agent&quot; be rake beaker
+</code></pre>
 
 <h3>Facter facts</h3>
 
@@ -239,9 +252,9 @@ the config_mode to be set, but only the boolean <code>enabled</code> is set.</p>
 </div></div>
 
       <div id="footer">
-  Generated on Fri Jan 13 15:43:22 2017 by
+  Generated on Tue Jan 31 20:51:44 2017 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
-  0.9.7 (ruby-2.3.3).
+  0.9.8 (ruby-2.3.3).
 </div>
 
     </div>

--- a/docs/frames.html
+++ b/docs/frames.html
@@ -2,7 +2,7 @@
 <html>
 <head>
   <meta charset="utf-8">
-	<title>Documentation by YARD 0.9.7</title>
+	<title>Documentation by YARD 0.9.8</title>
 </head>
 <script type="text/javascript" charset="utf-8">
   var match = unescape(window.location.hash).match(/^#!(.+)/);

--- a/docs/index.html
+++ b/docs/index.html
@@ -6,7 +6,7 @@
 <title>
   File: README
   
-    &mdash; Documentation by YARD 0.9.7
+    &mdash; Documentation by YARD 0.9.8
   
 </title>
 
@@ -85,7 +85,7 @@
 <h2>Requirements</h2>
 
 <ul>
-<li>Puppet 3.8.7 or later</li>
+<li>Puppet 4 or later</li>
 </ul>
 
 <h2>Module Description</h2>
@@ -108,7 +108,11 @@ running system.</p>
 <li>If SELinux is disabled and you want to switch to permissive or enforcing you
 are required to reboot the system (limitation of SELinux). The module won&#39;t
 do this for you.</li>
-<li>If you add filecontexts with <code>semange fcontext</code> (what <code>selinux::fcontext</code> 
+<li>If SELinux is disabled and the user wants enforcing mode, the module
+will downgrade to permissive mode instead to avoid transitioning directly from
+disabled to enforcing state after a reboot and potentially breaking the system.
+The user will receive a warning when this happens,</li>
+<li>If you add filecontexts with <code>semanage fcontext</code> (what <code>selinux::fcontext</code>
 does) the order is important. If you add /my/folder before /my/folder/subfolder
 only /my/folder will match (limitation of SELinux). There is no such limitation
 to file-contexts defined in SELinux modules. (GH-121)</li>
@@ -117,19 +121,21 @@ interfaces (<code>*.if</code>) or file-contexts (<code>*.fc</code>).</li>
 <li>While SELinux is disabled the defined types <code>selinux::boolean</code>, 
 <code>selinux::fcontext</code>, <code>selinux::port</code> will produce puppet agent runtime errors 
 because the used tools fail.</li>
-<li><code>selinux::port</code> has the <code>action</code> parameter which  if you specify <code>-d</code> or 
-<code>--delete</code> silently does nothing. (GH-164)</li>
-<li><code>selinux::permissive</code> allows only to set a domain to permissive but not to
-remove it. (GH-165)</li>
+<li>If you try to remove a built-in permissive type, the operation will appear to succeed
+but will actually have no effect, making your puppet runs non-idempotent.</li>
+<li>The <code>selinux_port</code> provider may misbehave if the title does not correspond to
+the format it expects. Users should use the <code>selinux::port</code> define instead except
+when purging resources</li>
+<li>Defining port ranges that overlap with existing ranges is currently not detected, and will
+cause semanage to error when the resource is applied.</li>
 </ul>
 
 <h2>Usage</h2>
 
-<p>There is puppet-strings generated documentation available in the docs/ folder 
-of the github repo.</p>
+<p>Generated puppet strings documentation with examples is available from
+<a href="https://voxpupuli.org/puppet-selinux/">https://voxpupuli.org/puppet-selinux/</a></p>
 
-<p>It will be available at <a href="http://voxpupuli.org/pupppet-selinux">http://voxpupuli.org/pupppet-selinux</a> some time in 
-the future.</p>
+<p>It&#39;s also included in the docs/ folder as simple html pages.</p>
 
 <h2>Reference</h2>
 
@@ -189,7 +195,14 @@ to fully take effect. It will run in <code>permissive</code> mode until then.</p
 adding or changing something</li>
 <li>Only few <code>--list</code> operations work</li>
 </ul></li>
+<li>run acceptance tests:</li>
 </ul>
+
+<pre class="code ruby"><code class="ruby">BEAKER_debug=yes BEAKER_set=&quot;centos-6-x64&quot; PUPPET_INSTALL_TYPE=&quot;agent&quot; be rake beaker
+BEAKER_debug=yes BEAKER_set=&quot;centos-7-x64&quot; PUPPET_INSTALL_TYPE=&quot;agent&quot; be rake beaker
+BEAKER_debug=yes BEAKER_set=&quot;fedora-24-x64&quot; PUPPET_INSTALL_TYPE=&quot;agent&quot; be rake beaker
+BEAKER_debug=yes BEAKER_set=&quot;fedora-25-x64&quot; PUPPET_INSTALL_TYPE=&quot;agent&quot; be rake beaker
+</code></pre>
 
 <h3>Facter facts</h3>
 
@@ -239,9 +252,9 @@ the config_mode to be set, but only the boolean <code>enabled</code> is set.</p>
 </div></div>
 
       <div id="footer">
-  Generated on Fri Jan 13 15:43:22 2017 by
+  Generated on Tue Jan 31 20:51:44 2017 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
-  0.9.7 (ruby-2.3.3).
+  0.9.8 (ruby-2.3.3).
 </div>
 
     </div>

--- a/docs/puppet_class_list.html
+++ b/docs/puppet_class_list.html
@@ -32,6 +32,14 @@
               Defined Types
             </a></span>
           
+            <span><a target="_self" href="puppet_type_list.html">
+              Resource Types
+            </a></span>
+          
+            <span><a target="_self" href="puppet_provider_list.html">
+              Providers
+            </a></span>
+          
         </div>
 
         <div id="search">Search: <input type="text" /></div>

--- a/docs/puppet_classes/selinux.html
+++ b/docs/puppet_classes/selinux.html
@@ -6,7 +6,7 @@
 <title>
   Puppet Class: selinux
   
-    &mdash; Documentation by YARD 0.9.7
+    &mdash; Documentation by YARD 0.9.8
   
 </title>
 
@@ -422,19 +422,19 @@ class selinux (
   class { &#39;::selinux::config&#39;: }
 
   if $boolean {
-    create_resources ( &#39;selinux::boolean&#39;, hiera_hash(&#39;selinux::boolean&#39;) )
+    create_resources ( &#39;selinux::boolean&#39;, hiera_hash(&#39;selinux::boolean&#39;, $boolean) )
   }
   if $fcontext {
-    create_resources ( &#39;selinux::fcontext&#39;, hiera_hash(&#39;selinux::fcontext&#39;) )
+    create_resources ( &#39;selinux::fcontext&#39;, hiera_hash(&#39;selinux::fcontext&#39;, $fcontext) )
   }
   if $module {
-    create_resources ( &#39;selinux::module&#39;, hiera_hash(&#39;selinux::module&#39;) )
+    create_resources ( &#39;selinux::module&#39;, hiera_hash(&#39;selinux::module&#39;, $module) )
   }
   if $permissive {
-    create_resources ( &#39;selinux::fcontext&#39;, hiera_hash(&#39;selinux::permissive&#39;) )
+    create_resources ( &#39;selinux::permissive&#39;, hiera_hash(&#39;selinux::permissive&#39;, $permissive) )
   }
   if $port {
-    create_resources ( &#39;selinux::port&#39;, hiera_hash(&#39;selinux::port&#39;) )
+    create_resources ( &#39;selinux::port&#39;, hiera_hash(&#39;selinux::port&#39;, $port) )
   }
 
   # Ordering
@@ -452,9 +452,9 @@ class selinux (
 </div>
 
       <div id="footer">
-  Generated on Fri Jan 13 15:43:22 2017 by
+  Generated on Tue Jan 31 20:51:44 2017 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
-  0.9.7 (ruby-2.3.3).
+  0.9.8 (ruby-2.3.3).
 </div>
 
     </div>

--- a/docs/puppet_classes/selinux_3A_3Aconfig.html
+++ b/docs/puppet_classes/selinux_3A_3Aconfig.html
@@ -6,7 +6,7 @@
 <title>
   Puppet Class: selinux::config
   
-    &mdash; Documentation by YARD 0.9.7
+    &mdash; Documentation by YARD 0.9.8
   
 </title>
 
@@ -248,7 +248,14 @@
 79
 80
 81
-82</pre>
+82
+83
+84
+85
+86
+87
+88
+89</pre>
       </td>
       <td>
         <pre class="code"><span class="info file"># File 'manifests/config.pp', line 16</span>
@@ -271,17 +278,24 @@ class selinux::config (
     group  =&gt; &#39;root&#39;,
   }
 
-  if $mode {
-    file_line { &quot;set-selinux-config-to-${mode}&quot;:
+  if ($mode == &#39;enforcing&#39; and !$::selinux) {
+    notice(&#39;SELinux is disabled. Forcing configuration to permissive to avoid problems. To disable this warning, explicitly set selinux::mode to permissive or disabled.&#39;)
+    $_real_mode = &#39;permissive&#39;
+  } else {
+    $_real_mode = $mode
+  }
+
+  if $_real_mode {
+    file_line { &quot;set-selinux-config-to-${_real_mode}&quot;:
       path  =&gt; &#39;/etc/selinux/config&#39;,
-      line  =&gt; &quot;SELINUX=${mode}&quot;,
+      line  =&gt; &quot;SELINUX=${_real_mode}&quot;,
       match =&gt; &#39;^SELINUX=\w+&#39;,
     }
 
-    case $mode {
+    case $_real_mode {
       &#39;permissive&#39;, &#39;disabled&#39;: {
         $sestatus = &#39;0&#39;
-        if $mode == &#39;disabled&#39; and defined(&#39;$::selinux_current_mode&#39;) and $::selinux_current_mode == &#39;permissive&#39; {
+        if $_real_mode == &#39;disabled&#39; and defined(&#39;$::selinux_current_mode&#39;) and $::selinux_current_mode == &#39;permissive&#39; {
           notice(&#39;A reboot is required to fully disable SELinux. SELinux will operate in Permissive mode until a reboot&#39;)
         }
       }
@@ -295,19 +309,19 @@ class selinux::config (
 
     # a complete relabeling is required when switching from disabled to
     # permissive or enforcing. Ensure the autorelabel trigger file is created.
-    if $mode in [&#39;enforcing&#39;,&#39;permissive&#39;] and
+    if $_real_mode in [&#39;enforcing&#39;,&#39;permissive&#39;] and
       !$::selinux {
       file { &#39;/.autorelabel&#39;:
         ensure  =&gt; &#39;file&#39;,
         owner   =&gt; &#39;root&#39;,
         group   =&gt; &#39;root&#39;,
-        content =&gt; &quot;# created by puppet for disabled to ${mode} switch\n&quot;,
+        content =&gt; &quot;# created by puppet for disabled to ${_real_mode} switch\n&quot;,
       }
     }
 
-    exec { &quot;change-selinux-status-to-${mode}&quot;:
+    exec { &quot;change-selinux-status-to-${_real_mode}&quot;:
       command =&gt; &quot;setenforce ${sestatus}&quot;,
-      unless  =&gt; &quot;getenforce | grep -Eqi &#39;${mode}|disabled&#39;&quot;,
+      unless  =&gt; &quot;getenforce | grep -Eqi &#39;${_real_mode}|disabled&#39;&quot;,
       path    =&gt; &#39;/bin:/sbin:/usr/bin:/usr/sbin&#39;,
     }
   }
@@ -327,9 +341,9 @@ class selinux::config (
 </div>
 
       <div id="footer">
-  Generated on Fri Jan 13 15:43:22 2017 by
+  Generated on Tue Jan 31 20:51:44 2017 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
-  0.9.7 (ruby-2.3.3).
+  0.9.8 (ruby-2.3.3).
 </div>
 
     </div>

--- a/docs/puppet_classes/selinux_3A_3Apackage.html
+++ b/docs/puppet_classes/selinux_3A_3Apackage.html
@@ -6,7 +6,7 @@
 <title>
   Puppet Class: selinux::package
   
-    &mdash; Documentation by YARD 0.9.7
+    &mdash; Documentation by YARD 0.9.8
   
 </title>
 
@@ -162,9 +162,9 @@ class selinux::package (
 </div>
 
       <div id="footer">
-  Generated on Fri Jan 13 15:43:22 2017 by
+  Generated on Tue Jan 31 20:51:44 2017 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
-  0.9.7 (ruby-2.3.3).
+  0.9.8 (ruby-2.3.3).
 </div>
 
     </div>

--- a/docs/puppet_classes/selinux_3A_3Aparams.html
+++ b/docs/puppet_classes/selinux_3A_3Aparams.html
@@ -6,7 +6,7 @@
 <title>
   Puppet Class: selinux::params
   
-    &mdash; Documentation by YARD 0.9.7
+    &mdash; Documentation by YARD 0.9.8
   
 </title>
 
@@ -279,9 +279,9 @@ class selinux::params {
 </div>
 
       <div id="footer">
-  Generated on Fri Jan 13 15:43:22 2017 by
+  Generated on Tue Jan 31 20:51:44 2017 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
-  0.9.7 (ruby-2.3.3).
+  0.9.8 (ruby-2.3.3).
 </div>
 
     </div>

--- a/docs/puppet_classes/selinux_3A_3Arestorecond.html
+++ b/docs/puppet_classes/selinux_3A_3Arestorecond.html
@@ -6,7 +6,7 @@
 <title>
   Puppet Class: selinux::restorecond
   
-    &mdash; Documentation by YARD 0.9.7
+    &mdash; Documentation by YARD 0.9.8
   
 </title>
 
@@ -201,9 +201,9 @@ class selinux::restorecond (
 </div>
 
       <div id="footer">
-  Generated on Fri Jan 13 15:43:22 2017 by
+  Generated on Tue Jan 31 20:51:44 2017 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
-  0.9.7 (ruby-2.3.3).
+  0.9.8 (ruby-2.3.3).
 </div>
 
     </div>

--- a/docs/puppet_classes/selinux_3A_3Arestorecond_3A_3Aservice.html
+++ b/docs/puppet_classes/selinux_3A_3Arestorecond_3A_3Aservice.html
@@ -6,7 +6,7 @@
 <title>
   Puppet Class: selinux::restorecond::service
   
-    &mdash; Documentation by YARD 0.9.7
+    &mdash; Documentation by YARD 0.9.8
   
 </title>
 
@@ -116,9 +116,9 @@ class selinux::restorecond::service {
 </div>
 
       <div id="footer">
-  Generated on Fri Jan 13 15:43:22 2017 by
+  Generated on Tue Jan 31 20:51:44 2017 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
-  0.9.7 (ruby-2.3.3).
+  0.9.8 (ruby-2.3.3).
 </div>
 
     </div>

--- a/docs/puppet_defined_type_list.html
+++ b/docs/puppet_defined_type_list.html
@@ -32,6 +32,14 @@
               Defined Types
             </a></span>
           
+            <span><a target="_self" href="puppet_type_list.html">
+              Resource Types
+            </a></span>
+          
+            <span><a target="_self" href="puppet_provider_list.html">
+              Providers
+            </a></span>
+          
         </div>
 
         <div id="search">Search: <input type="text" /></div>
@@ -54,28 +62,35 @@
     </li>
     
 
-    <li id="object_puppet_defined_types::selinux::module" class="odd">
+    <li id="object_puppet_defined_types::selinux::fcontext::equivalence" class="odd">
+      <div class="item">
+        <span class='object_link'><a href="puppet_defined_types/selinux_3A_3Afcontext_3A_3Aequivalence.html" title="puppet_defined_types::selinux::fcontext::equivalence (puppet_defined_type)">selinux::fcontext::equivalence</a></span>
+      </div>
+    </li>
+    
+
+    <li id="object_puppet_defined_types::selinux::module" class="even">
       <div class="item">
         <span class='object_link'><a href="puppet_defined_types/selinux_3A_3Amodule.html" title="puppet_defined_types::selinux::module (puppet_defined_type)">selinux::module</a></span>
       </div>
     </li>
     
 
-    <li id="object_puppet_defined_types::selinux::permissive" class="even">
+    <li id="object_puppet_defined_types::selinux::permissive" class="odd">
       <div class="item">
         <span class='object_link'><a href="puppet_defined_types/selinux_3A_3Apermissive.html" title="puppet_defined_types::selinux::permissive (puppet_defined_type)">selinux::permissive</a></span>
       </div>
     </li>
     
 
-    <li id="object_puppet_defined_types::selinux::port" class="odd">
+    <li id="object_puppet_defined_types::selinux::port" class="even">
       <div class="item">
         <span class='object_link'><a href="puppet_defined_types/selinux_3A_3Aport.html" title="puppet_defined_types::selinux::port (puppet_defined_type)">selinux::port</a></span>
       </div>
     </li>
     
 
-    <li id="object_puppet_defined_types::selinux::restorecond::fragment" class="even">
+    <li id="object_puppet_defined_types::selinux::restorecond::fragment" class="odd">
       <div class="item">
         <span class='object_link'><a href="puppet_defined_types/selinux_3A_3Arestorecond_3A_3Afragment.html" title="puppet_defined_types::selinux::restorecond::fragment (puppet_defined_type)">selinux::restorecond::fragment</a></span>
       </div>

--- a/docs/puppet_defined_types/selinux_3A_3Afcontext.html
+++ b/docs/puppet_defined_types/selinux_3A_3Afcontext.html
@@ -6,7 +6,7 @@
 <title>
   Defined Type: selinux::fcontext
   
-    &mdash; Documentation by YARD 0.9.7
+    &mdash; Documentation by YARD 0.9.8
   
 </title>
 
@@ -73,16 +73,8 @@
   <div class="discussion">
     <p>selinux::fcontext</p>
 
-<p>This method will manage a local file context setting, and will persist it across reboots.
-It will perform a check to ensure the file context is not already set.</p>
-
-<p>example Add a file-context only for directory types
-  selinux::fcontext{&#39;set-non-home-user-dir_type_d&#39;:
-    filetype =&gt; true ,
-    filemode =&gt; &#39;d&#39; ,
-    context  =&gt; &#39;user_home_dir_t&#39; ,
-    pathname =&gt; &#39;/u/users/[^/]*&#39; ,
-  }</p>
+<p>This define can be used to manage custom SELinux fcontexts. For fcontext
+equivalences, see selinux::fcontext::equivalence</p>
 
   </div>
 </div>
@@ -92,22 +84,21 @@ It will perform a check to ensure the file context is not already set.</p>
     <p class="tag_title">Examples:</p>
     
       
-        <p class="example_title"><div class='inline'><p>Add an path substition (equal) file-context</p>
-</div></p>
-      
-      <pre class="example code"><code>selinux::fcontext{&#39;set-postfix-instance1-spool&#39;:
-  equals      =&gt; true,
-  pathname    =&gt; &#39;/var/spool/postfix-instance1&#39;,
-  destination =&gt; &#39;/var/spool/postfix&#39;
-}</code></pre>
-    
-      
         <p class="example_title"><div class='inline'><p>Add a file-context for mysql log files at non standard location</p>
 </div></p>
       
       <pre class="example code"><code>selinux::fcontext{&#39;set-mysql-log-context&#39;:
-  context =&gt; &quot;mysqld_log_t&quot;,
+  seltype =&gt; &quot;mysqld_log_t&quot;,
   pathname =&gt; &quot;/u01/log/mysql(/.*)?&quot;,
+}</code></pre>
+    
+      
+        <p class="example_title"><div class='inline'><p>Add a file-context only for directory types</p>
+</div></p>
+      
+      <pre class="example code"><code>selinux::fcontext{&#39;/u/users/[^/]*&#39;:
+  filetype =&gt; &#39;d&#39;,
+  seltype  =&gt; &#39;user_home_dir_t&#39; ,
 }</code></pre>
     
   </div>
@@ -116,66 +107,69 @@ It will perform a check to ensure the file context is not already set.</p>
   
     <li>
       
-        <span class='name'>context</span>
+        <span class='name'>ensure</span>
       
       
-        <span class='type'>(<tt>Any</tt>)</span>
+        <span class='type'>(<tt>Enum['absent', 'present']</tt>)</span>
+      
+      
+        <em class="default">(defaults to: <tt>&#39;present&#39;</tt>)</em>
+      
+      
+        &mdash;
+        <div class='inline'><p>The desired state of the resource. Default: &#39;present&#39;</p>
+</div>
+      
+    </li>
+  
+    <li>
+      
+        <span class='name'>seltype</span>
+      
+      
+        <span class='type'>(<tt>Optional[String]</tt>)</span>
       
       
         <em class="default">(defaults to: <tt>undef</tt>)</em>
       
       
         &mdash;
-        <div class='inline'><p>A particular file-context, like &quot;mysqld_log_t&quot;</p>
+        <div class='inline'><p>String A particular SELinux type, like &quot;mysqld_log_t&quot;</p>
 </div>
       
     </li>
   
     <li>
       
-        <span class='name'>pathname</span>
+        <span class='name'>seluser</span>
       
       
-        <span class='type'>(<tt>Any</tt>)</span>
-      
-      
-      
-        &mdash;
-        <div class='inline'><p>An semanage fcontext-formatted pathname, like &quot;/var/log/mysql(/.*)?&quot;</p>
-</div>
-      
-    </li>
-  
-    <li>
-      
-        <span class='name'>destination</span>
-      
-      
-        <span class='type'>(<tt>Any</tt>)</span>
+        <span class='type'>(<tt>Optional[String]</tt>)</span>
       
       
         <em class="default">(defaults to: <tt>undef</tt>)</em>
       
       
         &mdash;
-        <div class='inline'><p>The destination path used with the equals parameter.</p>
+        <div class='inline'><p>String A particular SELinux user, like &quot;sysadm_u&quot;</p>
 </div>
       
     </li>
   
     <li>
       
-        <span class='name'>equals</span>
+        <span class='name'>pathspec</span>
       
       
-        <span class='type'>(<tt>Any</tt>)</span>
+        <span class='type'>(<tt>String</tt>)</span>
       
       
-        <em class="default">(defaults to: <tt>false</tt>)</em>
+        <em class="default">(defaults to: <tt>$title</tt>)</em>
       
       
         &mdash;
-        <div class='inline'><p>Boolean Value - Enables support for substituting target path with sourcepath when generating default label</p>
+        <div class='inline'><p>String An semanage fcontext-formatted path specification,
+like &quot;/var/log/mysql(/.*)?&quot;. Defaults to title</p>
 </div>
       
     </li>
@@ -185,31 +179,14 @@ It will perform a check to ensure the file context is not already set.</p>
         <span class='name'>filetype</span>
       
       
-        <span class='type'>(<tt>Any</tt>)</span>
-      
-      
-        <em class="default">(defaults to: <tt>false</tt>)</em>
-      
-      
-        &mdash;
-        <div class='inline'><p>Boolean Value - enables support for &quot;-f&quot; file type option of &quot;semanage fcontext&quot;</p>
-</div>
-      
-    </li>
-  
-    <li>
-      
-        <span class='name'>filemode</span>
-      
-      
-        <span class='type'>(<tt>Any</tt>)</span>
+        <span class='type'>(<tt>Optional[String]</tt>)</span>
       
       
         <em class="default">(defaults to: <tt>&#39;a&#39;</tt>)</em>
       
       
         &mdash;
-        <div class='inline'><p>File Mode for policy (i.e. regular file, directory, block device, all files, etc.)</p>
+        <div class='inline'><p>File type the context applies to (i.e. regular file, directory, block device, all files, etc.)</p>
 
 <ul>
 <li>Types:
@@ -229,57 +206,6 @@ It will perform a check to ensure the file context is not already set.</p>
       
     </li>
   
-    <li>
-      
-        <span class='name'>restorecond</span>
-      
-      
-        <span class='type'>(<tt>Any</tt>)</span>
-      
-      
-        <em class="default">(defaults to: <tt>true</tt>)</em>
-      
-      
-        &mdash;
-        <div class='inline'><p>Run restorecon against the path name upon changes (default true)</p>
-</div>
-      
-    </li>
-  
-    <li>
-      
-        <span class='name'>restorecond_path</span>
-      
-      
-        <span class='type'>(<tt>Any</tt>)</span>
-      
-      
-        <em class="default">(defaults to: <tt>undef</tt>)</em>
-      
-      
-        &mdash;
-        <div class='inline'><p>Path name to use for restorecon (default $pathname)</p>
-</div>
-      
-    </li>
-  
-    <li>
-      
-        <span class='name'>restorecond_recurse</span>
-      
-      
-        <span class='type'>(<tt>Any</tt>)</span>
-      
-      
-        <em class="default">(defaults to: <tt>false</tt>)</em>
-      
-      
-        &mdash;
-        <div class='inline'><p>Run restorecon recursive?</p>
-</div>
-      
-    </li>
-  
 </ul>
 
 
@@ -290,6 +216,19 @@ It will perform a check to ensure the file context is not already set.</p>
         <pre class="lines">
 
 
+33
+34
+35
+36
+37
+38
+39
+40
+41
+42
+43
+44
+45
 46
 47
 48
@@ -307,174 +246,41 @@ It will perform a check to ensure the file context is not already set.</p>
 60
 61
 62
-63
-64
-65
-66
-67
-68
-69
-70
-71
-72
-73
-74
-75
-76
-77
-78
-79
-80
-81
-82
-83
-84
-85
-86
-87
-88
-89
-90
-91
-92
-93
-94
-95
-96
-97
-98
-99
-100
-101
-102
-103
-104
-105
-106
-107
-108
-109
-110
-111
-112
-113
-114
-115
-116
-117
-118
-119
-120
-121
-122
-123
-124
-125
-126
-127
-128
-129
-130
-131
-132
-133
-134
-135
-136</pre>
+63</pre>
       </td>
       <td>
-        <pre class="code"><span class="info file"># File 'manifests/fcontext.pp', line 46</span>
+        <pre class="code"><span class="info file"># File 'manifests/fcontext.pp', line 33</span>
 
-define selinux::fcontext (
-  $pathname,
-  $destination         = undef,
-  $context             = undef,
-  $filetype            = false,
-  $filemode            = &#39;a&#39;,
-  $equals              = false,
-  $restorecond         = true,
-  $restorecond_path    = undef,
-  $restorecond_recurse = false,
+define selinux::fcontext(
+  String $pathspec                  = $title,
+  Enum[&#39;absent&#39;, &#39;present&#39;] $ensure = &#39;present&#39;,
+  Optional[String] $seltype         = undef,
+  Optional[String] $seluser         = undef,
+  Optional[String] $filetype        = &#39;a&#39;,
 ) {
 
   include ::selinux
-
+  if $ensure == &#39;present&#39; {
   Anchor[&#39;selinux::module post&#39;] -&gt;
   Selinux::Fcontext[$title] -&gt;
   Anchor[&#39;selinux::end&#39;]
-
-  validate_absolute_path($pathname)
-  validate_bool($filetype, $equals)
-
-  if $equals {
-    validate_absolute_path($destination)
   } else {
-    validate_string($context)
+    Anchor[&#39;selinux::start&#39;] -&gt;
+    Selinux::Fcontext[$title] -&gt;
+    Anchor[&#39;selinux::module::pre&#39;]
   }
 
-  $restorecond_path_private = $restorecond_path ? {
-    undef   =&gt; $pathname,
-    default =&gt; $restorecond_path
+  if $filetype !~ /^(?:a|f|d|c|b|s|l|p)$/ {
+    fail(&#39;&quot;filetype&quot; must be one of: a,f,d,c,b,s,l,p - see &quot;man semanage-fcontext&quot;&#39;)
   }
 
-  validate_absolute_path($restorecond_path_private)
-
-  $restorecond_resurse_private = $restorecond_recurse ? {
-    true  =&gt; [&#39;-R&#39;],
-    false =&gt; [],
+  # make sure the title is correct or the provider will misbehave
+  selinux_fcontext {&quot;${pathspec}_${filetype}&quot;:
+    pathspec  =&gt; $pathspec,
+    seltype   =&gt; $seltype,
+    file_type =&gt; $filetype,
+    seluser   =&gt; $seluser,
   }
-
-  if $equals and $filetype {
-    fail(&#39;Resource cannot contain both &quot;equals&quot; and &quot;filetype&quot; options&#39;)
-  }
-
-  if $equals {
-    $resource_name = &quot;add_${destination}_${pathname}&quot;
-    $command       = shellquote(&#39;semanage&#39;, &#39;fcontext&#39;,&#39;-a&#39;, &#39;-e&#39;, $destination, $pathname)
-    $unless        = sprintf(&#39;semanage fcontext -l | grep -Fx %s&#39;, shellquote(&quot;${pathname} = ${destination}&quot;))
-  } else {
-    if $filemode !~ /^(?:a|f|d|c|b|s|l|p)$/ {
-      fail(&#39;&quot;filemode&quot; must be one of: a,f,d,c,b,s,l,p - see &quot;man semanage-fcontext&quot;&#39;)
-    }
-    $resource_name = &quot;add_${context}_${pathname}_type_${filemode}&quot;
-    if $::osfamily == &#39;RedHat&#39; and $::operatingsystemmajrelease == &#39;6&#39; {
-      case $filemode {
-        &#39;a&#39;: {
-          $_filemode = &#39;all files&#39;
-          $_quotedfilemode = &#39;\&#39;all files\&#39;&#39;
-          }
-        default: {
-          $_filemode = $filemode
-          $_quotedfilemode = $_filemode
-        }
-      }
-    } else {
-      $_filemode = $filemode
-      $_quotedfilemode = $_filemode
-    }
-    $command       = shellquote(&#39;semanage&#39;, &#39;fcontext&#39;,&#39;-a&#39;, &#39;-f&#39;, $_filemode, &#39;-t&#39;, $context, $pathname)
-    $unless        = sprintf(&#39;semanage fcontext -E | grep -Fx %s&#39;, shellquote(&quot;fcontext -a -f ${_quotedfilemode} -t ${context} &#39;${pathname}&#39;&quot;))
-  }
-
-  Exec {
-    path =&gt; &#39;/bin:/sbin:/usr/bin:/usr/sbin&#39;,
-  }
-
-  exec { $resource_name:
-    command =&gt; $command,
-    unless  =&gt; $unless,
-    require =&gt; Class[&#39;selinux::package&#39;],
-  }
-
-  if $restorecond {
-    exec { &quot;restorecond ${resource_name}&quot;:
-      command     =&gt; shellquote(&#39;restorecon&#39;, $restorecond_resurse_private, $restorecond_path_private),
-      onlyif      =&gt; shellquote(&#39;test&#39;, &#39;-e&#39;, $restorecond_path_private),
-      refreshonly =&gt; true,
-      subscribe   =&gt; Exec[$resource_name],
-    }
-  }
-
 }</pre>
       </td>
     </tr>
@@ -483,9 +289,9 @@ define selinux::fcontext (
 </div>
 
       <div id="footer">
-  Generated on Fri Jan 13 15:43:22 2017 by
+  Generated on Tue Jan 31 20:51:44 2017 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
-  0.9.7 (ruby-2.3.3).
+  0.9.8 (ruby-2.3.3).
 </div>
 
     </div>

--- a/docs/puppet_defined_types/selinux_3A_3Afcontext_3A_3Aequivalence.html
+++ b/docs/puppet_defined_types/selinux_3A_3Afcontext_3A_3Aequivalence.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>
-  Defined Type: selinux::boolean
+  Defined Type: selinux::fcontext::equivalence
   
     &mdash; Documentation by YARD 0.9.8
   
@@ -15,7 +15,7 @@
   <link rel="stylesheet" href="../css/common.css" type="text/css" charset="utf-8" />
 
 <script type="text/javascript" charset="utf-8">
-  pathId = "puppet_defined_types::selinux::boolean";
+  pathId = "puppet_defined_types::selinux::fcontext::equivalence";
   relpath = '../';
 </script>
 
@@ -39,7 +39,7 @@
     <a href="../_index.html">Index (s)</a> &raquo;
     <span class='title'><span class='object_link'>Defined Types</span></span>
      &raquo; 
-    <span class="title">selinux::boolean</span>
+    <span class="title">selinux::fcontext::equivalence</span>
   
 </div>
 
@@ -59,21 +59,21 @@
         <div class="clear"></div>
       </div>
 
-      <div id="content"><h1>Defined Type: selinux::boolean</h1>
+      <div id="content"><h1>Defined Type: selinux::fcontext::equivalence</h1>
 <div class="box_info">
   <dl>
     <dt>Defined in:</dt>
     <dd>
-      manifests/boolean.pp
+      manifests/fcontext/equivalence.pp
     </dd>
   </dl>
 </div>
 <h2>Overview</h2>
 <div class="docstring">
   <div class="discussion">
-    <p>selinux::boolean</p>
+    <p>selinux::fcontext::equivalence</p>
 
-<p>This class will set the state of an SELinux boolean.</p>
+<p>This define can be used to manage SELinux fcontext equivalences</p>
 
   </div>
 </div>
@@ -83,19 +83,12 @@
     <p class="tag_title">Examples:</p>
     
       
-        <p class="example_title"><div class='inline'><p>Enable <code>named_write_master_zones</code> boolean</p>
+        <p class="example_title"><div class='inline'><p>Make /opt/wordpress equivalent to /usr/share/wordpress</p>
 </div></p>
       
-      <pre class="example code"><code>selinux::boolean{ &#39;named_write_master_zones&#39;:
-   ensure     =&gt; &quot;on&quot;,
-}</code></pre>
-    
-      
-        <p class="example_title"><div class='inline'><p>Ensure <code>named_write_master_zones</code> boolean is disabled</p>
-</div></p>
-      
-      <pre class="example code"><code>selinux::boolean{ &#39;named_write_master_zones&#39;:
-   ensure     =&gt; &quot;off&quot;,
+      <pre class="example code"><code>selinux::fcontext::equivalence { &#39;/opt/wordpress&#39;:
+  ensure =&gt; &#39;present&#39;,
+  target =&gt; &#39;/usr/share/wordpress&#39;,
 }</code></pre>
     
   </div>
@@ -104,34 +97,49 @@
   
     <li>
       
-        <span class='name'>ensure</span>
+        <span class='name'>path</span>
       
       
-        <span class='type'>(<tt>Any</tt>)</span>
+        <span class='type'>(<tt>String</tt>)</span>
       
       
-        <em class="default">(defaults to: <tt>&#39;on&#39;</tt>)</em>
+        <em class="default">(defaults to: <tt>$title</tt>)</em>
       
       
         &mdash;
-        <div class='inline'><p>Set to on or off</p>
+        <div class='inline'><p>the path to define and equivalence for. Default: Resource title</p>
 </div>
       
     </li>
   
     <li>
       
-        <span class='name'>persistent</span>
+        <span class='name'>target</span>
       
       
-        <span class='type'>(<tt>Any</tt>)</span>
+        <span class='type'>(<tt>String</tt>)</span>
       
-      
-        <em class="default">(defaults to: <tt>true</tt>)</em>
       
       
         &mdash;
-        <div class='inline'><p>Set to false if you don&#39;t want it to survive a reboot.</p>
+        <div class='inline'><p>the path that this resource will be equivalent to.</p>
+</div>
+      
+    </li>
+  
+    <li>
+      
+        <span class='name'>ensure</span>
+      
+      
+        <span class='type'>(<tt>Enum['present', 'absent']</tt>)</span>
+      
+      
+        <em class="default">(defaults to: <tt>&#39;present&#39;</tt>)</em>
+      
+      
+        &mdash;
+        <div class='inline'><p>the desired state of the equivalence. Default: present</p>
 </div>
       
     </li>
@@ -146,6 +154,9 @@
         <pre class="lines">
 
 
+15
+16
+17
 18
 19
 20
@@ -165,51 +176,32 @@
 34
 35
 36
-37
-38
-39
-40
-41
-42
-43
-44
-45
-46
-47
-48</pre>
+37</pre>
       </td>
       <td>
-        <pre class="code"><span class="info file"># File 'manifests/boolean.pp', line 18</span>
+        <pre class="code"><span class="info file"># File 'manifests/fcontext/equivalence.pp', line 15</span>
 
-define selinux::boolean (
-  $ensure     = &#39;on&#39;,
-  $persistent = true,
+define selinux::fcontext::equivalence(
+  String $target,
+  String $path = $title,
+  Enum[&#39;present&#39;, &#39;absent&#39;] $ensure = &#39;present&#39;
 ) {
 
   include ::selinux
 
-  Anchor[&#39;selinux::module post&#39;] -&gt;
-  Selinux::Boolean[$title] -&gt;
-  Anchor[&#39;selinux::end&#39;]
-
-  $ensure_real = $ensure ? {
-    true    =&gt; &#39;true&#39;, # lint:ignore:quoted_booleans
-    false   =&gt; &#39;false&#39;, # lint:ignore:quoted_booleans
-    default =&gt; $ensure,
+  if $ensure == &#39;present&#39; {
+    Anchor[&#39;selinux::module post&#39;] -&gt;
+    Selinux::Fcontext::Equivalence[$title] -&gt;
+    Anchor[&#39;selinux::end&#39;]
+  } else {
+    Anchor[&#39;selinux::start&#39;] -&gt;
+    Selinux::Fcontext::Equivalence[$title] -&gt;
+    Anchor[&#39;selinux::module pre&#39;]
   }
 
-  validate_re($ensure_real, [&#39;^on$&#39;, &#39;^true$&#39;, &#39;^present$&#39;, &#39;^off$&#39;, &#39;^false$&#39;, &#39;^absent$&#39;], &#39;Valid ensures must be one of on, true, present, off, false, or absent&#39;)
-  validate_bool($persistent)
-
-  $value = $ensure_real ? {
-    /(?i-mx:on|true|present)/  =&gt; &#39;on&#39;,
-    /(?i-mx:off|false|absent)/ =&gt; &#39;off&#39;,
-    default                    =&gt; undef,
-  }
-
-  selboolean { $name:
-    value      =&gt; $value,
-    persistent =&gt; $persistent,
+  selinux_fcontext_equivalence { $path:
+    ensure =&gt; $ensure,
+    target =&gt; $target,
   }
 }</pre>
       </td>

--- a/docs/puppet_defined_types/selinux_3A_3Amodule.html
+++ b/docs/puppet_defined_types/selinux_3A_3Amodule.html
@@ -6,7 +6,7 @@
 <title>
   Defined Type: selinux::module
   
-    &mdash; Documentation by YARD 0.9.7
+    &mdash; Documentation by YARD 0.9.8
   
 </title>
 
@@ -360,9 +360,9 @@ define selinux::module(
 </div>
 
       <div id="footer">
-  Generated on Fri Jan 13 15:43:22 2017 by
+  Generated on Tue Jan 31 20:51:44 2017 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
-  0.9.7 (ruby-2.3.3).
+  0.9.8 (ruby-2.3.3).
 </div>
 
     </div>

--- a/docs/puppet_defined_types/selinux_3A_3Apermissive.html
+++ b/docs/puppet_defined_types/selinux_3A_3Apermissive.html
@@ -6,7 +6,7 @@
 <title>
   Defined Type: selinux::permissive
   
-    &mdash; Documentation by YARD 0.9.7
+    &mdash; Documentation by YARD 0.9.8
   
 </title>
 
@@ -73,7 +73,7 @@
   <div class="discussion">
     <p>selinux::permissive</p>
 
-<p>This method will set a context to permissive</p>
+<p>This define will set an SELinux type to permissive</p>
 
   </div>
 </div>
@@ -86,8 +86,8 @@
         <p class="example_title"><div class='inline'><p>Mark oddjob_mkhomedir_t permissive</p>
 </div></p>
       
-      <pre class="example code"><code>selinux::permissive { &#39;allow-oddjob_mkhomedir_t&#39;:
-  context  =&gt; &#39;oddjob_mkhomedir_t&#39;,
+      <pre class="example code"><code>selinux::permissive { &#39;oddjob_mkhomedir_t&#39;:
+  ensure =&gt; &#39;present&#39;
 }</code></pre>
     
   </div>
@@ -96,15 +96,34 @@
   
     <li>
       
-        <span class='name'>context</span>
+        <span class='name'>ensure</span>
       
       
-        <span class='type'>(<tt>Any</tt>)</span>
+        <span class='type'>(<tt>Enum['present', 'absent']</tt>)</span>
       
+      
+        <em class="default">(defaults to: <tt>&#39;present&#39;</tt>)</em>
       
       
         &mdash;
-        <div class='inline'><p>A particular domain-context, like &quot;oddjob_mkhomedir_t&quot;</p>
+        <div class='inline'><p>Set to present to add or absent to remove a permissive mode of a type</p>
+</div>
+      
+    </li>
+  
+    <li>
+      
+        <span class='name'>seltype</span>
+      
+      
+        <span class='type'>(<tt>String</tt>)</span>
+      
+      
+        <em class="default">(defaults to: <tt>$title</tt>)</em>
+      
+      
+        &mdash;
+        <div class='inline'><p>A particular selinux type to make permissive, like &quot;oddjob_mkhomedir_t&quot;</p>
 </div>
       
     </li>
@@ -119,7 +138,6 @@
         <pre class="lines">
 
 
-12
 13
 14
 15
@@ -135,26 +153,33 @@
 25
 26
 27
-28</pre>
+28
+29
+30
+31
+32</pre>
       </td>
       <td>
-        <pre class="code"><span class="info file"># File 'manifests/permissive.pp', line 12</span>
+        <pre class="code"><span class="info file"># File 'manifests/permissive.pp', line 13</span>
 
 define selinux::permissive (
-  $context,
+  String $seltype = $title,
+  Enum[&#39;present&#39;, &#39;absent&#39;] $ensure = &#39;present&#39;,
 ) {
 
   include ::selinux
+  if $ensure == &#39;present&#39; {
+    Anchor[&#39;selinux::module post&#39;] -&gt;
+    Selinux::Permissive[$title] -&gt;
+    Anchor[&#39;selinux::end&#39;]
+  } else {
+    Anchor[&#39;selinux::start&#39;] -&gt;
+    Selinux::Permissive[$title] -&gt;
+    Anchor[&#39;selinux::module pre&#39;]
+  }
 
-  Anchor[&#39;selinux::module post&#39;] -&gt;
-  Selinux::Permissive[$title] -&gt;
-  Anchor[&#39;selinux::end&#39;]
-
-  exec { &quot;add_${context}&quot;:
-    command =&gt; shellquote(&#39;semanage&#39;, &#39;permissive&#39;, &#39;-a&#39;, $context),
-    unless  =&gt; sprintf(&#39;semanage permissive -l | grep -Fx %s&#39;, shellquote($context)),
-    path    =&gt; &#39;/bin:/sbin:/usr/bin:/usr/sbin&#39;,
-    require =&gt; Class[&#39;selinux::package&#39;],
+  selinux_permissive {$seltype:
+    ensure =&gt; $ensure,
   }
 }</pre>
       </td>
@@ -164,9 +189,9 @@ define selinux::permissive (
 </div>
 
       <div id="footer">
-  Generated on Fri Jan 13 15:43:22 2017 by
+  Generated on Tue Jan 31 20:51:44 2017 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
-  0.9.7 (ruby-2.3.3).
+  0.9.8 (ruby-2.3.3).
 </div>
 
     </div>

--- a/docs/puppet_defined_types/selinux_3A_3Aport.html
+++ b/docs/puppet_defined_types/selinux_3A_3Aport.html
@@ -6,7 +6,7 @@
 <title>
   Defined Type: selinux::port
   
-    &mdash; Documentation by YARD 0.9.7
+    &mdash; Documentation by YARD 0.9.8
   
 </title>
 
@@ -71,11 +71,10 @@
 <h2>Overview</h2>
 <div class="docstring">
   <div class="discussion">
-    <p>selinux::fcontext</p>
+    <p>selinux::port</p>
 
 <p>This method will manage a local network port context setting, and will
-persist it across reboots.
-It will perform a check to ensure the network context is not already set.</p>
+persist it across reboots.</p>
 
   </div>
 </div>
@@ -89,9 +88,10 @@ It will perform a check to ensure the network context is not already set.</p>
 </div></p>
       
       <pre class="example code"><code>selinux::port { &#39;allow-syslog-relp&#39;:
-  context  =&gt; &#39;syslogd_port_t&#39;,
+  ensure   =&gt; &#39;present&#39;,
+  seltype  =&gt; &#39;syslogd_port_t&#39;,
   protocol =&gt; &#39;tcp&#39;,
-  port     =&gt; &#39;8514&#39;,
+  port     =&gt; 8514,
 }</code></pre>
     
   </div>
@@ -100,15 +100,32 @@ It will perform a check to ensure the network context is not already set.</p>
   
     <li>
       
-        <span class='name'>context</span>
+        <span class='name'>ensure</span>
       
       
-        <span class='type'>(<tt>Any</tt>)</span>
+        <span class='type'>(<tt>Enum['present', 'absent']</tt>)</span>
+      
+      
+        <em class="default">(defaults to: <tt>&#39;present&#39;</tt>)</em>
+      
+      
+        &mdash;
+        <div class='inline'><p>Set to present to add or absent to remove a port context.</p>
+</div>
+      
+    </li>
+  
+    <li>
+      
+        <span class='name'>seltype</span>
+      
+      
+        <span class='type'>(<tt>String</tt>)</span>
       
       
       
         &mdash;
-        <div class='inline'><p>A port-context name</p>
+        <div class='inline'><p>An SELinux port type</p>
 </div>
       
     </li>
@@ -118,14 +135,12 @@ It will perform a check to ensure the network context is not already set.</p>
         <span class='name'>protocol</span>
       
       
-        <span class='type'>(<tt>Any</tt>)</span>
+        <span class='type'>(<tt>Enum['tcp', 'udp']</tt>)</span>
       
-      
-        <em class="default">(defaults to: <tt>undef</tt>)</em>
       
       
         &mdash;
-        <div class='inline'><p>Either tcp or udp. If unset, omits -p flag from semanage.</p>
+        <div class='inline'><p>Either &#39;tcp&#39;, &#39;udp&#39;, &#39;ipv4&#39; or &#39;ipv6&#39;</p>
 </div>
       
     </li>
@@ -135,29 +150,31 @@ It will perform a check to ensure the network context is not already set.</p>
         <span class='name'>port</span>
       
       
-        <span class='type'>(<tt>Any</tt>)</span>
+        <span class='type'>(<tt>Optional[Integer[1,65535]]</tt>)</span>
       
+      
+        <em class="default">(defaults to: <tt>undef</tt>)</em>
       
       
         &mdash;
-        <div class='inline'><p>An network port number, like &#39;8514&#39;</p>
+        <div class='inline'><p>A network port number, like 8514,</p>
 </div>
       
     </li>
   
     <li>
       
-        <span class='name'>argument</span>
+        <span class='name'>port_range</span>
       
       
-        <span class='type'>(<tt>Any</tt>)</span>
+        <span class='type'>(<tt>Optional[Tuple[Integer[1,65535], 2, 2]]</tt>)</span>
       
       
-        <em class="default">(defaults to: <tt>&#39;-a&#39;</tt>)</em>
+        <em class="default">(defaults to: <tt>undef</tt>)</em>
       
       
         &mdash;
-        <div class='inline'><p>An argument for semanage port. Default: &quot;-a&quot;</p>
+        <div class='inline'><p>A port-range tuple, eg. [9090, 9095].</p>
 </div>
       
     </li>
@@ -172,7 +189,6 @@ It will perform a check to ensure the network context is not already set.</p>
         <pre class="lines">
 
 
-19
 20
 21
 22
@@ -203,41 +219,72 @@ It will perform a check to ensure the network context is not already set.</p>
 47
 48
 49
-50</pre>
+50
+51
+52
+53
+54
+55
+56
+57
+58
+59
+60
+61
+62
+63
+64
+65
+66</pre>
       </td>
       <td>
-        <pre class="code"><span class="info file"># File 'manifests/port.pp', line 19</span>
+        <pre class="code"><span class="info file"># File 'manifests/port.pp', line 20</span>
 
 define selinux::port (
-  $context,
-  $port,
-  $protocol = undef,
-  $argument = &#39;-a&#39;,
+  String                             $seltype,
+  Enum[&#39;tcp&#39;, &#39;udp&#39;]                 $protocol,
+  Optional[Integer[1,65535]]         $port = undef,
+  Optional[Tuple[Integer[1,65535], 2, 2]] $port_range = undef,
+  Enum[&#39;present&#39;, &#39;absent&#39;]          $ensure = &#39;present&#39;,
 ) {
 
   include ::selinux
 
-  Anchor[&#39;selinux::module post&#39;] -&gt;
-  Selinux::Port[$title] -&gt;
-  Anchor[&#39;selinux::end&#39;]
-
-  if $protocol {
-    validate_re($protocol, [&#39;^tcp6?$&#39;, &#39;^udp6?$&#39;])
-    $protocol_switch = [&#39;-p&#39;, $protocol]
-    $protocol_check = &quot;${protocol} &quot;
-    $port_exec_command = &quot;add_${context}_${port}_${protocol}&quot;
+  if $ensure == &#39;present&#39; {
+    Anchor[&#39;selinux::module post&#39;] -&gt;
+    Selinux::Port[$title] -&gt;
+    Anchor[&#39;selinux::end&#39;]
+  } elsif $ensure == &#39;absent&#39; {
+    Class[&#39;selinux::config&#39;] -&gt;
+    Selinux::Port[$title] -&gt;
+    Anchor[&#39;selinux::module pre&#39;]
   } else {
-    $protocol_switch = []
-    $protocol_check = &#39;&#39; # lint:ignore:empty_string_assignment variable is used to create regexp and undef is not possible
-    $port_exec_command = &quot;add_${context}_${port}&quot;
+    fail(&#39;Unexpected $ensure value&#39;)
   }
 
-  exec { $port_exec_command:
-    command =&gt; shellquote(&#39;semanage&#39;, &#39;port&#39;, $argument, &#39;-t&#39;, $context, $protocol_switch, &quot;${port}&quot;), # lint:ignore:only_variable_string port can be number and we need to force it to be string for shellquote
-    # This works because there seems to be more than one space after protocol and before first port
-    unless  =&gt; sprintf(&#39;semanage port -l | grep -E %s&#39;, shellquote(&quot;^${context}  *${protocol_check}.* ${port}(\$|,)&quot;)),
-    path    =&gt; &#39;/bin:/sbin:/usr/bin:/usr/sbin&#39;,
-    require =&gt; Class[&#39;selinux::package&#39;],
+  if ($port == undef and $port_range == undef) {
+    fail(&quot;You must define either &#39;port&#39; or &#39;port_range&#39;&quot;)
+  }
+  if ($port != undef and $port_range != undef) {
+    fail(&quot;You can&#39;t define both &#39;port&#39; and &#39;port_range&#39;&quot;)
+  }
+
+  $range = $port_range ? {
+    undef   =&gt; [$port, $port],
+    default =&gt; $port_range,
+  }
+
+  # this can only happen if port_range is used
+  if $range[0] &gt; $range[1] {
+    fail(&quot;Malformed port range: ${port_range}&quot;)
+  }
+
+  selinux_port {&quot;${protocol}_${range[0]}-${range[1]}&quot;:
+    ensure    =&gt; $ensure,
+    low_port  =&gt; $range[0],
+    high_port =&gt; $range[1],
+    seltype   =&gt; $seltype,
+    protocol  =&gt; $protocol,
   }
 }</pre>
       </td>
@@ -247,9 +294,9 @@ define selinux::port (
 </div>
 
       <div id="footer">
-  Generated on Fri Jan 13 15:43:22 2017 by
+  Generated on Tue Jan 31 20:51:44 2017 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
-  0.9.7 (ruby-2.3.3).
+  0.9.8 (ruby-2.3.3).
 </div>
 
     </div>

--- a/docs/puppet_defined_types/selinux_3A_3Arestorecond_3A_3Afragment.html
+++ b/docs/puppet_defined_types/selinux_3A_3Arestorecond_3A_3Afragment.html
@@ -6,7 +6,7 @@
 <title>
   Defined Type: selinux::restorecond::fragment
   
-    &mdash; Documentation by YARD 0.9.7
+    &mdash; Documentation by YARD 0.9.8
   
 </title>
 
@@ -185,9 +185,9 @@ define selinux::restorecond::fragment (
 </div>
 
       <div id="footer">
-  Generated on Fri Jan 13 15:43:22 2017 by
+  Generated on Tue Jan 31 20:51:44 2017 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
-  0.9.7 (ruby-2.3.3).
+  0.9.8 (ruby-2.3.3).
 </div>
 
     </div>

--- a/docs/puppet_provider_list.html
+++ b/docs/puppet_provider_list.html
@@ -1,0 +1,87 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta charset="utf-8" />
+    
+      <link rel="stylesheet" href="css/full_list.css" type="text/css" media="screen" charset="utf-8" />
+    
+      <link rel="stylesheet" href="css/common.css" type="text/css" media="screen" charset="utf-8" />
+    
+
+    
+      <script type="text/javascript" charset="utf-8" src="js/jquery.js"></script>
+    
+      <script type="text/javascript" charset="utf-8" src="js/full_list.js"></script>
+    
+
+    <title>Provider List</title>
+    <base id="base_target" target="_parent" />
+  </head>
+  <body>
+    <div id="content">
+      <div class="fixed_header">
+        <h1 id="full_list_header">Provider List</h1>
+        <div id="full_list_nav">
+          
+            <span><a target="_self" href="puppet_class_list.html">
+              Puppet Classes
+            </a></span>
+          
+            <span><a target="_self" href="puppet_defined_type_list.html">
+              Defined Types
+            </a></span>
+          
+            <span><a target="_self" href="puppet_type_list.html">
+              Resource Types
+            </a></span>
+          
+            <span><a target="_self" href="puppet_provider_list.html">
+              Providers
+            </a></span>
+          
+        </div>
+
+        <div id="search">Search: <input type="text" /></div>
+      </div>
+
+      <ul id="full_list" class="puppet_provider">
+        
+
+    <li id="object_puppet_providers_selinux_port::semanage" class="odd">
+      <div class="item">
+        <span class='object_link'><a href="puppet_providers_selinux_port/semanage.html" title="puppet_providers_selinux_port::semanage (puppet_provider)">semanage</a></span>
+        <small>Resource type: <em>selinux_port</em></small>
+      </div>
+    </li>
+    
+
+    <li id="object_puppet_providers_selinux_fcontext::semanage" class="even">
+      <div class="item">
+        <span class='object_link'><a href="puppet_providers_selinux_fcontext/semanage.html" title="puppet_providers_selinux_fcontext::semanage (puppet_provider)">semanage</a></span>
+        <small>Resource type: <em>selinux_fcontext</em></small>
+      </div>
+    </li>
+    
+
+    <li id="object_puppet_providers_selinux_permissive::semanage" class="odd">
+      <div class="item">
+        <span class='object_link'><a href="puppet_providers_selinux_permissive/semanage.html" title="puppet_providers_selinux_permissive::semanage (puppet_provider)">semanage</a></span>
+        <small>Resource type: <em>selinux_permissive</em></small>
+      </div>
+    </li>
+    
+
+    <li id="object_puppet_providers_selinux_fcontext_equivalence::semanage" class="even">
+      <div class="item">
+        <span class='object_link'><a href="puppet_providers_selinux_fcontext_equivalence/semanage.html" title="puppet_providers_selinux_fcontext_equivalence::semanage (puppet_provider)">semanage</a></span>
+        <small>Resource type: <em>selinux_fcontext_equivalence</em></small>
+      </div>
+    </li>
+    
+
+
+      </ul>
+    </div>
+  </body>
+</html>

--- a/docs/puppet_providers_selinux_fcontext/semanage.html
+++ b/docs/puppet_providers_selinux_fcontext/semanage.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>
-  Puppet Class: selinux::restorecond::config
+  Provider: semanage
   
     &mdash; Documentation by YARD 0.9.8
   
@@ -15,7 +15,7 @@
   <link rel="stylesheet" href="../css/common.css" type="text/css" charset="utf-8" />
 
 <script type="text/javascript" charset="utf-8">
-  pathId = "puppet_classes::selinux::restorecond::config";
+  pathId = "puppet_providers_selinux_fcontext::semanage";
   relpath = '../';
 </script>
 
@@ -28,7 +28,7 @@
   </head>
   <body>
     <div class="nav_wrap">
-      <iframe id="nav" src="../puppet_class_list.html?1"></iframe>
+      <iframe id="nav" src="../puppet_provider_list.html?1"></iframe>
       <div id="resizer"></div>
     </div>
 
@@ -37,9 +37,9 @@
         <div id="menu">
   
     <a href="../_index.html">Index (s)</a> &raquo;
-    <span class='title'><span class='object_link'>Puppet Classes</span></span>
+    <span class='title'><span class='object_link'>Providers</span></span>
      &raquo; 
-    <span class="title">selinux::restorecond::config</span>
+    <span class="title">semanage</span>
   
 </div>
 
@@ -59,76 +59,69 @@
         <div class="clear"></div>
       </div>
 
-      <div id="content"><h1>Puppet Class: selinux::restorecond::config</h1>
+      <div id="content"><h1>Provider: semanage</h1>
 <div class="box_info">
-  
-  
   <dl>
     <dt>Defined in:</dt>
     <dd>
-      manifests/restorecond/config.pp
+      lib/puppet/provider/selinux_fcontext/semanage.rb
     </dd>
+  </dl>
+  <dl>
+    <dt>Resource type:</dt>
+    <dd><span class='object_link'><a href="../puppet_types/selinux_fcontext.html" title="puppet_types::selinux_fcontext (puppet_type)">selinux_fcontext</a></span></dd>
   </dl>
 </div>
 <h2>Overview</h2>
 <div class="docstring">
   <div class="discussion">
-    <p>selinux::restorecond::config</p>
-
-<h1>THIS IS A PRIVATE CLASS</h1>
+    <p>Support managing SELinux custom fcontext definitions via semanage</p>
 
   </div>
 </div>
 <div class="tags">
   
 
-</div><div class="method_details_list">
-  <table class="source_code">
-    <tr>
-      <td>
-        <pre class="lines">
-
-
-6
-7
-8
-9
-10
-11
-12
-13
-14
-15
-16
-17
-18
-19
-20
-21</pre>
-      </td>
-      <td>
-        <pre class="code"><span class="info file"># File 'manifests/restorecond/config.pp', line 6</span>
-
-class selinux::restorecond::config {
-
-  concat { $selinux::restorecond::config_file:
-    ensure =&gt; present,
-    mode   =&gt; $selinux::restorecond::config_file_mode,
-    owner  =&gt; $selinux::restorecond::config_file_owner,
-    group  =&gt; $selinux::restorecond::config_file_group,
-    notify =&gt; Service[&#39;restorecond&#39;],
-  }
-
-  concat::fragment {&#39;restorecond_config_default&#39;:
-    target =&gt; $selinux::restorecond::config_file,
-    source =&gt; &#39;puppet:///modules/selinux/restorecond.conf&#39;,
-    order  =&gt; &#39;01&#39;,
-  }
-}</pre>
-      </td>
-    </tr>
-  </table>
 </div>
+
+<div class="tags">
+  <p class="tag_title">Confines</p>
+  <ul>
+
+  
+    
+      <li><tt>selinux &mdash; true</tt></li>
+    
+  
+  </ul>
+</div>
+
+
+<div class="tags">
+  <p class="tag_title">Default Provider For</p>
+  <ul>
+
+  
+    
+      <li><tt>kernel &mdash; Linux</tt></li>
+    
+  
+  </ul>
+</div>
+
+
+<div class="tags">
+  <p class="tag_title">Commands</p>
+  <ul>
+
+  
+    
+      <li><tt>semanage &mdash; semanage</tt></li>
+    
+  
+  </ul>
+</div>
+
 </div>
 
       <div id="footer">

--- a/docs/puppet_providers_selinux_fcontext_equivalence/semanage.html
+++ b/docs/puppet_providers_selinux_fcontext_equivalence/semanage.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>
-  Puppet Class: selinux::restorecond::config
+  Provider: semanage
   
     &mdash; Documentation by YARD 0.9.8
   
@@ -15,7 +15,7 @@
   <link rel="stylesheet" href="../css/common.css" type="text/css" charset="utf-8" />
 
 <script type="text/javascript" charset="utf-8">
-  pathId = "puppet_classes::selinux::restorecond::config";
+  pathId = "puppet_providers_selinux_fcontext_equivalence::semanage";
   relpath = '../';
 </script>
 
@@ -28,7 +28,7 @@
   </head>
   <body>
     <div class="nav_wrap">
-      <iframe id="nav" src="../puppet_class_list.html?1"></iframe>
+      <iframe id="nav" src="../puppet_provider_list.html?1"></iframe>
       <div id="resizer"></div>
     </div>
 
@@ -37,9 +37,9 @@
         <div id="menu">
   
     <a href="../_index.html">Index (s)</a> &raquo;
-    <span class='title'><span class='object_link'>Puppet Classes</span></span>
+    <span class='title'><span class='object_link'>Providers</span></span>
      &raquo; 
-    <span class="title">selinux::restorecond::config</span>
+    <span class="title">semanage</span>
   
 </div>
 
@@ -59,76 +59,69 @@
         <div class="clear"></div>
       </div>
 
-      <div id="content"><h1>Puppet Class: selinux::restorecond::config</h1>
+      <div id="content"><h1>Provider: semanage</h1>
 <div class="box_info">
-  
-  
   <dl>
     <dt>Defined in:</dt>
     <dd>
-      manifests/restorecond/config.pp
+      lib/puppet/provider/selinux_fcontext_equivalence/semanage.rb
     </dd>
+  </dl>
+  <dl>
+    <dt>Resource type:</dt>
+    <dd><span class='object_link'><a href="../puppet_types/selinux_fcontext_equivalence.html" title="puppet_types::selinux_fcontext_equivalence (puppet_type)">selinux_fcontext_equivalence</a></span></dd>
   </dl>
 </div>
 <h2>Overview</h2>
 <div class="docstring">
   <div class="discussion">
-    <p>selinux::restorecond::config</p>
-
-<h1>THIS IS A PRIVATE CLASS</h1>
+    <p>Support managing SELinux custom fcontext definitions via semanage</p>
 
   </div>
 </div>
 <div class="tags">
   
 
-</div><div class="method_details_list">
-  <table class="source_code">
-    <tr>
-      <td>
-        <pre class="lines">
-
-
-6
-7
-8
-9
-10
-11
-12
-13
-14
-15
-16
-17
-18
-19
-20
-21</pre>
-      </td>
-      <td>
-        <pre class="code"><span class="info file"># File 'manifests/restorecond/config.pp', line 6</span>
-
-class selinux::restorecond::config {
-
-  concat { $selinux::restorecond::config_file:
-    ensure =&gt; present,
-    mode   =&gt; $selinux::restorecond::config_file_mode,
-    owner  =&gt; $selinux::restorecond::config_file_owner,
-    group  =&gt; $selinux::restorecond::config_file_group,
-    notify =&gt; Service[&#39;restorecond&#39;],
-  }
-
-  concat::fragment {&#39;restorecond_config_default&#39;:
-    target =&gt; $selinux::restorecond::config_file,
-    source =&gt; &#39;puppet:///modules/selinux/restorecond.conf&#39;,
-    order  =&gt; &#39;01&#39;,
-  }
-}</pre>
-      </td>
-    </tr>
-  </table>
 </div>
+
+<div class="tags">
+  <p class="tag_title">Confines</p>
+  <ul>
+
+  
+    
+      <li><tt>selinux &mdash; true</tt></li>
+    
+  
+  </ul>
+</div>
+
+
+<div class="tags">
+  <p class="tag_title">Default Provider For</p>
+  <ul>
+
+  
+    
+      <li><tt>kernel &mdash; Linux</tt></li>
+    
+  
+  </ul>
+</div>
+
+
+<div class="tags">
+  <p class="tag_title">Commands</p>
+  <ul>
+
+  
+    
+      <li><tt>semanage &mdash; semanage</tt></li>
+    
+  
+  </ul>
+</div>
+
 </div>
 
       <div id="footer">

--- a/docs/puppet_providers_selinux_permissive/semanage.html
+++ b/docs/puppet_providers_selinux_permissive/semanage.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>
-  Puppet Class: selinux::restorecond::config
+  Provider: semanage
   
     &mdash; Documentation by YARD 0.9.8
   
@@ -15,7 +15,7 @@
   <link rel="stylesheet" href="../css/common.css" type="text/css" charset="utf-8" />
 
 <script type="text/javascript" charset="utf-8">
-  pathId = "puppet_classes::selinux::restorecond::config";
+  pathId = "puppet_providers_selinux_permissive::semanage";
   relpath = '../';
 </script>
 
@@ -28,7 +28,7 @@
   </head>
   <body>
     <div class="nav_wrap">
-      <iframe id="nav" src="../puppet_class_list.html?1"></iframe>
+      <iframe id="nav" src="../puppet_provider_list.html?1"></iframe>
       <div id="resizer"></div>
     </div>
 
@@ -37,9 +37,9 @@
         <div id="menu">
   
     <a href="../_index.html">Index (s)</a> &raquo;
-    <span class='title'><span class='object_link'>Puppet Classes</span></span>
+    <span class='title'><span class='object_link'>Providers</span></span>
      &raquo; 
-    <span class="title">selinux::restorecond::config</span>
+    <span class="title">semanage</span>
   
 </div>
 
@@ -59,76 +59,69 @@
         <div class="clear"></div>
       </div>
 
-      <div id="content"><h1>Puppet Class: selinux::restorecond::config</h1>
+      <div id="content"><h1>Provider: semanage</h1>
 <div class="box_info">
-  
-  
   <dl>
     <dt>Defined in:</dt>
     <dd>
-      manifests/restorecond/config.pp
+      lib/puppet/provider/selinux_permissive/semanage.rb
     </dd>
+  </dl>
+  <dl>
+    <dt>Resource type:</dt>
+    <dd><span class='object_link'><a href="../puppet_types/selinux_permissive.html" title="puppet_types::selinux_permissive (puppet_type)">selinux_permissive</a></span></dd>
   </dl>
 </div>
 <h2>Overview</h2>
 <div class="docstring">
   <div class="discussion">
-    <p>selinux::restorecond::config</p>
-
-<h1>THIS IS A PRIVATE CLASS</h1>
+    <p>Support managing SELinux permissive types definitions via semanage</p>
 
   </div>
 </div>
 <div class="tags">
   
 
-</div><div class="method_details_list">
-  <table class="source_code">
-    <tr>
-      <td>
-        <pre class="lines">
-
-
-6
-7
-8
-9
-10
-11
-12
-13
-14
-15
-16
-17
-18
-19
-20
-21</pre>
-      </td>
-      <td>
-        <pre class="code"><span class="info file"># File 'manifests/restorecond/config.pp', line 6</span>
-
-class selinux::restorecond::config {
-
-  concat { $selinux::restorecond::config_file:
-    ensure =&gt; present,
-    mode   =&gt; $selinux::restorecond::config_file_mode,
-    owner  =&gt; $selinux::restorecond::config_file_owner,
-    group  =&gt; $selinux::restorecond::config_file_group,
-    notify =&gt; Service[&#39;restorecond&#39;],
-  }
-
-  concat::fragment {&#39;restorecond_config_default&#39;:
-    target =&gt; $selinux::restorecond::config_file,
-    source =&gt; &#39;puppet:///modules/selinux/restorecond.conf&#39;,
-    order  =&gt; &#39;01&#39;,
-  }
-}</pre>
-      </td>
-    </tr>
-  </table>
 </div>
+
+<div class="tags">
+  <p class="tag_title">Confines</p>
+  <ul>
+
+  
+    
+      <li><tt>selinux &mdash; true</tt></li>
+    
+  
+  </ul>
+</div>
+
+
+<div class="tags">
+  <p class="tag_title">Default Provider For</p>
+  <ul>
+
+  
+    
+      <li><tt>kernel &mdash; Linux</tt></li>
+    
+  
+  </ul>
+</div>
+
+
+<div class="tags">
+  <p class="tag_title">Commands</p>
+  <ul>
+
+  
+    
+      <li><tt>semanage &mdash; semanage</tt></li>
+    
+  
+  </ul>
+</div>
+
 </div>
 
       <div id="footer">

--- a/docs/puppet_providers_selinux_port/semanage.html
+++ b/docs/puppet_providers_selinux_port/semanage.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>
-  Puppet Class: selinux::restorecond::config
+  Provider: semanage
   
     &mdash; Documentation by YARD 0.9.8
   
@@ -15,7 +15,7 @@
   <link rel="stylesheet" href="../css/common.css" type="text/css" charset="utf-8" />
 
 <script type="text/javascript" charset="utf-8">
-  pathId = "puppet_classes::selinux::restorecond::config";
+  pathId = "puppet_providers_selinux_port::semanage";
   relpath = '../';
 </script>
 
@@ -28,7 +28,7 @@
   </head>
   <body>
     <div class="nav_wrap">
-      <iframe id="nav" src="../puppet_class_list.html?1"></iframe>
+      <iframe id="nav" src="../puppet_provider_list.html?1"></iframe>
       <div id="resizer"></div>
     </div>
 
@@ -37,9 +37,9 @@
         <div id="menu">
   
     <a href="../_index.html">Index (s)</a> &raquo;
-    <span class='title'><span class='object_link'>Puppet Classes</span></span>
+    <span class='title'><span class='object_link'>Providers</span></span>
      &raquo; 
-    <span class="title">selinux::restorecond::config</span>
+    <span class="title">semanage</span>
   
 </div>
 
@@ -59,76 +59,71 @@
         <div class="clear"></div>
       </div>
 
-      <div id="content"><h1>Puppet Class: selinux::restorecond::config</h1>
+      <div id="content"><h1>Provider: semanage</h1>
 <div class="box_info">
-  
-  
   <dl>
     <dt>Defined in:</dt>
     <dd>
-      manifests/restorecond/config.pp
+      lib/puppet/provider/selinux_port/semanage.rb
     </dd>
+  </dl>
+  <dl>
+    <dt>Resource type:</dt>
+    <dd><span class='object_link'><a href="../puppet_types/selinux_port.html" title="puppet_types::selinux_port (puppet_type)">selinux_port</a></span></dd>
   </dl>
 </div>
 <h2>Overview</h2>
 <div class="docstring">
   <div class="discussion">
-    <p>selinux::restorecond::config</p>
-
-<h1>THIS IS A PRIVATE CLASS</h1>
+    <p>Support managing SELinux custom port definitions via semanage</p>
 
   </div>
 </div>
 <div class="tags">
   
 
-</div><div class="method_details_list">
-  <table class="source_code">
-    <tr>
-      <td>
-        <pre class="lines">
-
-
-6
-7
-8
-9
-10
-11
-12
-13
-14
-15
-16
-17
-18
-19
-20
-21</pre>
-      </td>
-      <td>
-        <pre class="code"><span class="info file"># File 'manifests/restorecond/config.pp', line 6</span>
-
-class selinux::restorecond::config {
-
-  concat { $selinux::restorecond::config_file:
-    ensure =&gt; present,
-    mode   =&gt; $selinux::restorecond::config_file_mode,
-    owner  =&gt; $selinux::restorecond::config_file_owner,
-    group  =&gt; $selinux::restorecond::config_file_group,
-    notify =&gt; Service[&#39;restorecond&#39;],
-  }
-
-  concat::fragment {&#39;restorecond_config_default&#39;:
-    target =&gt; $selinux::restorecond::config_file,
-    source =&gt; &#39;puppet:///modules/selinux/restorecond.conf&#39;,
-    order  =&gt; &#39;01&#39;,
-  }
-}</pre>
-      </td>
-    </tr>
-  </table>
 </div>
+
+<div class="tags">
+  <p class="tag_title">Confines</p>
+  <ul>
+
+  
+    
+      <li><tt>selinux &mdash; true</tt></li>
+    
+  
+  </ul>
+</div>
+
+
+<div class="tags">
+  <p class="tag_title">Default Provider For</p>
+  <ul>
+
+  
+    
+      <li><tt>kernel &mdash; Linux</tt></li>
+    
+  
+  </ul>
+</div>
+
+
+<div class="tags">
+  <p class="tag_title">Commands</p>
+  <ul>
+
+  
+    
+      <li><tt>semanage &mdash; semanage</tt></li>
+    
+      <li><tt>python &mdash; python_command</tt></li>
+    
+  
+  </ul>
+</div>
+
 </div>
 
       <div id="footer">

--- a/docs/puppet_type_list.html
+++ b/docs/puppet_type_list.html
@@ -1,0 +1,83 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta charset="utf-8" />
+    
+      <link rel="stylesheet" href="css/full_list.css" type="text/css" media="screen" charset="utf-8" />
+    
+      <link rel="stylesheet" href="css/common.css" type="text/css" media="screen" charset="utf-8" />
+    
+
+    
+      <script type="text/javascript" charset="utf-8" src="js/jquery.js"></script>
+    
+      <script type="text/javascript" charset="utf-8" src="js/full_list.js"></script>
+    
+
+    <title>Resource Type List</title>
+    <base id="base_target" target="_parent" />
+  </head>
+  <body>
+    <div id="content">
+      <div class="fixed_header">
+        <h1 id="full_list_header">Resource Type List</h1>
+        <div id="full_list_nav">
+          
+            <span><a target="_self" href="puppet_class_list.html">
+              Puppet Classes
+            </a></span>
+          
+            <span><a target="_self" href="puppet_defined_type_list.html">
+              Defined Types
+            </a></span>
+          
+            <span><a target="_self" href="puppet_type_list.html">
+              Resource Types
+            </a></span>
+          
+            <span><a target="_self" href="puppet_provider_list.html">
+              Providers
+            </a></span>
+          
+        </div>
+
+        <div id="search">Search: <input type="text" /></div>
+      </div>
+
+      <ul id="full_list" class="puppet_type">
+        
+
+    <li id="object_puppet_types::selinux_fcontext" class="odd">
+      <div class="item">
+        <span class='object_link'><a href="puppet_types/selinux_fcontext.html" title="puppet_types::selinux_fcontext (puppet_type)">selinux_fcontext</a></span>
+      </div>
+    </li>
+    
+
+    <li id="object_puppet_types::selinux_fcontext_equivalence" class="even">
+      <div class="item">
+        <span class='object_link'><a href="puppet_types/selinux_fcontext_equivalence.html" title="puppet_types::selinux_fcontext_equivalence (puppet_type)">selinux_fcontext_equivalence</a></span>
+      </div>
+    </li>
+    
+
+    <li id="object_puppet_types::selinux_permissive" class="odd">
+      <div class="item">
+        <span class='object_link'><a href="puppet_types/selinux_permissive.html" title="puppet_types::selinux_permissive (puppet_type)">selinux_permissive</a></span>
+      </div>
+    </li>
+    
+
+    <li id="object_puppet_types::selinux_port" class="even">
+      <div class="item">
+        <span class='object_link'><a href="puppet_types/selinux_port.html" title="puppet_types::selinux_port (puppet_type)">selinux_port</a></span>
+      </div>
+    </li>
+    
+
+
+      </ul>
+    </div>
+  </body>
+</html>

--- a/docs/puppet_types/selinux_fcontext.html
+++ b/docs/puppet_types/selinux_fcontext.html
@@ -1,0 +1,316 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>
+  Resource Type: selinux_fcontext
+  
+    &mdash; Documentation by YARD 0.9.8
+  
+</title>
+
+  <link rel="stylesheet" href="../css/style.css" type="text/css" charset="utf-8" />
+
+  <link rel="stylesheet" href="../css/common.css" type="text/css" charset="utf-8" />
+
+<script type="text/javascript" charset="utf-8">
+  pathId = "puppet_types::selinux_fcontext";
+  relpath = '../';
+</script>
+
+
+  <script type="text/javascript" charset="utf-8" src="../js/jquery.js"></script>
+
+  <script type="text/javascript" charset="utf-8" src="../js/app.js"></script>
+
+
+  </head>
+  <body>
+    <div class="nav_wrap">
+      <iframe id="nav" src="../puppet_type_list.html?1"></iframe>
+      <div id="resizer"></div>
+    </div>
+
+    <div id="main" tabindex="-1">
+      <div id="header">
+        <div id="menu">
+  
+    <a href="../_index.html">Index (s)</a> &raquo;
+    <span class='title'><span class='object_link'>Resource Types</span></span>
+     &raquo; 
+    <span class="title">selinux_fcontext</span>
+  
+</div>
+
+        <div id="search">
+  
+    <a class="full_list_link" id="puppet_class_list_link"
+        href="../puppet_class_list.html">
+
+        <svg width="24" height="24">
+          <rect x="0" y="4" width="24" height="4" rx="1" ry="1"></rect>
+          <rect x="0" y="12" width="24" height="4" rx="1" ry="1"></rect>
+          <rect x="0" y="20" width="24" height="4" rx="1" ry="1"></rect>
+        </svg>
+    </a>
+  
+</div>
+        <div class="clear"></div>
+      </div>
+
+      <div id="content"><h1>Resource Type: selinux_fcontext</h1>
+<div class="box_info">
+  <dl>
+    <dt>Defined in:</dt>
+    <dd>
+      lib/puppet/type/selinux_fcontext.rb
+    </dd>
+  </dl>
+  
+  <dl>
+    <dt>Providers:</dt>
+    <dd>
+      
+        <span class='object_link'><a href="../puppet_providers_selinux_fcontext/semanage.html" title="puppet_providers_selinux_fcontext::semanage (puppet_provider)">semanage</a></span><br/>
+      
+    </dd>
+  </dl>
+  
+</div>
+<h2>Overview</h2>
+<div class="docstring">
+  <div class="discussion">
+    <p>Manage SELinux fcontext definitions. You should use selinux::fcontext instead of this directly.</p>
+
+  </div>
+</div>
+<div class="tags">
+  
+
+</div>
+<div class="tags">
+  <p class="tag_title">Properties</p>
+  <ul>
+    
+    <li>
+      <span class="name">ensure</span>
+      
+      <span class="default"> (defaults to: <em>present</em>)</span>
+      
+      
+      <div class="docstring">
+        <div class="discussion">
+          <p>The basic property that the resource should be in.</p>
+
+        </div>
+      </div>
+      
+      
+      <div>
+        Supported values:
+        <ul>
+          
+          <li>
+            
+            present
+          </li>
+          
+          <li>
+            
+            absent
+          </li>
+          
+        </ul>
+      </div>
+      
+    </li>
+    
+    <li>
+      <span class="name">file_type</span>
+      
+      <span class="default"> (defaults to: <em>a</em>)</span>
+      
+      
+      <div class="docstring">
+        <div class="discussion">
+          <p>The file type to match</p>
+
+        </div>
+      </div>
+      
+      
+      <div>
+        Supported values:
+        <ul>
+          
+          <li>
+            
+            %r{^[abcdflps]$}
+          </li>
+          
+        </ul>
+      </div>
+      
+    </li>
+    
+    <li>
+      <span class="name">selrange</span>
+      
+      
+      <div class="docstring">
+        <div class="discussion">
+          <p>The SELinux range</p>
+
+        </div>
+      </div>
+      
+      
+      <div>
+        Supported values:
+        <ul>
+          
+          <li>
+            
+            %r{\w+}
+          </li>
+          
+        </ul>
+      </div>
+      
+    </li>
+    
+    <li>
+      <span class="name">selrole</span>
+      
+      
+      <div class="docstring">
+        <div class="discussion">
+          <p>The SELinux role</p>
+
+        </div>
+      </div>
+      
+      
+      <div>
+        Supported values:
+        <ul>
+          
+          <li>
+            
+            %r{\w+}
+          </li>
+          
+        </ul>
+      </div>
+      
+    </li>
+    
+    <li>
+      <span class="name">seltype</span>
+      
+      
+      <div class="docstring">
+        <div class="discussion">
+          <p>The SELinux type to apply to the paths</p>
+
+        </div>
+      </div>
+      
+      
+      <div>
+        Supported values:
+        <ul>
+          
+          <li>
+            
+            %r{\w+}
+          </li>
+          
+          <li>
+            
+            <<none>>
+          </li>
+          
+        </ul>
+      </div>
+      
+    </li>
+    
+    <li>
+      <span class="name">seluser</span>
+      
+      
+      <div class="docstring">
+        <div class="discussion">
+          <p>The SELinux user name</p>
+
+        </div>
+      </div>
+      
+      
+      <div>
+        Supported values:
+        <ul>
+          
+          <li>
+            
+            %r{\w+}
+          </li>
+          
+        </ul>
+      </div>
+      
+    </li>
+    
+  </ul>
+</div>
+
+
+<div class="tags">
+  <p class="tag_title">Parameters</p>
+  <ul>
+    
+    <li>
+      <span class="name">pathspec</span>
+      
+      
+      <div class="docstring">
+        <div class="discussion">
+          <p>Path regular expression</p>
+
+        </div>
+      </div>
+      
+      
+    </li>
+    
+    <li>
+      <span class="name">title</span>
+      
+      
+      <div class="docstring">
+        <div class="discussion">
+          <p>The namevar. Should be of the format pathspec_filetype</p>
+
+        </div>
+      </div>
+      
+      
+    </li>
+    
+  </ul>
+</div>
+
+
+</div>
+
+      <div id="footer">
+  Generated on Tue Jan 31 20:51:44 2017 by
+  <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
+  0.9.8 (ruby-2.3.3).
+</div>
+
+    </div>
+  </body>
+</html>

--- a/docs/puppet_types/selinux_fcontext_equivalence.html
+++ b/docs/puppet_types/selinux_fcontext_equivalence.html
@@ -1,0 +1,179 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>
+  Resource Type: selinux_fcontext_equivalence
+  
+    &mdash; Documentation by YARD 0.9.8
+  
+</title>
+
+  <link rel="stylesheet" href="../css/style.css" type="text/css" charset="utf-8" />
+
+  <link rel="stylesheet" href="../css/common.css" type="text/css" charset="utf-8" />
+
+<script type="text/javascript" charset="utf-8">
+  pathId = "puppet_types::selinux_fcontext_equivalence";
+  relpath = '../';
+</script>
+
+
+  <script type="text/javascript" charset="utf-8" src="../js/jquery.js"></script>
+
+  <script type="text/javascript" charset="utf-8" src="../js/app.js"></script>
+
+
+  </head>
+  <body>
+    <div class="nav_wrap">
+      <iframe id="nav" src="../puppet_type_list.html?1"></iframe>
+      <div id="resizer"></div>
+    </div>
+
+    <div id="main" tabindex="-1">
+      <div id="header">
+        <div id="menu">
+  
+    <a href="../_index.html">Index (s)</a> &raquo;
+    <span class='title'><span class='object_link'>Resource Types</span></span>
+     &raquo; 
+    <span class="title">selinux_fcontext_equivalence</span>
+  
+</div>
+
+        <div id="search">
+  
+    <a class="full_list_link" id="puppet_class_list_link"
+        href="../puppet_class_list.html">
+
+        <svg width="24" height="24">
+          <rect x="0" y="4" width="24" height="4" rx="1" ry="1"></rect>
+          <rect x="0" y="12" width="24" height="4" rx="1" ry="1"></rect>
+          <rect x="0" y="20" width="24" height="4" rx="1" ry="1"></rect>
+        </svg>
+    </a>
+  
+</div>
+        <div class="clear"></div>
+      </div>
+
+      <div id="content"><h1>Resource Type: selinux_fcontext_equivalence</h1>
+<div class="box_info">
+  <dl>
+    <dt>Defined in:</dt>
+    <dd>
+      lib/puppet/type/selinux_fcontext_equivalence.rb
+    </dd>
+  </dl>
+  
+  <dl>
+    <dt>Providers:</dt>
+    <dd>
+      
+        <span class='object_link'><a href="../puppet_providers_selinux_fcontext_equivalence/semanage.html" title="puppet_providers_selinux_fcontext_equivalence::semanage (puppet_provider)">semanage</a></span><br/>
+      
+    </dd>
+  </dl>
+  
+</div>
+<h2>Overview</h2>
+<div class="docstring">
+  <div class="discussion">
+    <p>Manage SELinux fcontext equivalence definitions. You should use selinux::fcontext instead of this directly.</p>
+
+  </div>
+</div>
+<div class="tags">
+  
+
+</div>
+<div class="tags">
+  <p class="tag_title">Properties</p>
+  <ul>
+    
+    <li>
+      <span class="name">ensure</span>
+      
+      <span class="default"> (defaults to: <em>present</em>)</span>
+      
+      
+      <div class="docstring">
+        <div class="discussion">
+          <p>The basic property that the resource should be in.</p>
+
+        </div>
+      </div>
+      
+      
+      <div>
+        Supported values:
+        <ul>
+          
+          <li>
+            
+            present
+          </li>
+          
+          <li>
+            
+            absent
+          </li>
+          
+        </ul>
+      </div>
+      
+    </li>
+    
+    <li>
+      <span class="name">target</span>
+      
+      
+      <div class="docstring">
+        <div class="discussion">
+          <p>The target of the equivalence. ie. the path that this resource will be equivalent to</p>
+
+        </div>
+      </div>
+      
+      
+    </li>
+    
+  </ul>
+</div>
+
+
+<div class="tags">
+  <p class="tag_title">Parameters</p>
+  <ul>
+    
+    <li>
+      <span class="name">path</span>
+      
+      
+      <div class="docstring">
+        <div class="discussion">
+          <p>The path to set equivalence for</p>
+
+        </div>
+      </div>
+      
+      
+    </li>
+    
+  </ul>
+</div>
+
+
+</div>
+
+      <div id="footer">
+  Generated on Tue Jan 31 20:51:44 2017 by
+  <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
+  0.9.8 (ruby-2.3.3).
+</div>
+
+    </div>
+  </body>
+</html>

--- a/docs/puppet_types/selinux_permissive.html
+++ b/docs/puppet_types/selinux_permissive.html
@@ -1,0 +1,196 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>
+  Resource Type: selinux_permissive
+  
+    &mdash; Documentation by YARD 0.9.8
+  
+</title>
+
+  <link rel="stylesheet" href="../css/style.css" type="text/css" charset="utf-8" />
+
+  <link rel="stylesheet" href="../css/common.css" type="text/css" charset="utf-8" />
+
+<script type="text/javascript" charset="utf-8">
+  pathId = "puppet_types::selinux_permissive";
+  relpath = '../';
+</script>
+
+
+  <script type="text/javascript" charset="utf-8" src="../js/jquery.js"></script>
+
+  <script type="text/javascript" charset="utf-8" src="../js/app.js"></script>
+
+
+  </head>
+  <body>
+    <div class="nav_wrap">
+      <iframe id="nav" src="../puppet_type_list.html?1"></iframe>
+      <div id="resizer"></div>
+    </div>
+
+    <div id="main" tabindex="-1">
+      <div id="header">
+        <div id="menu">
+  
+    <a href="../_index.html">Index (s)</a> &raquo;
+    <span class='title'><span class='object_link'>Resource Types</span></span>
+     &raquo; 
+    <span class="title">selinux_permissive</span>
+  
+</div>
+
+        <div id="search">
+  
+    <a class="full_list_link" id="puppet_class_list_link"
+        href="../puppet_class_list.html">
+
+        <svg width="24" height="24">
+          <rect x="0" y="4" width="24" height="4" rx="1" ry="1"></rect>
+          <rect x="0" y="12" width="24" height="4" rx="1" ry="1"></rect>
+          <rect x="0" y="20" width="24" height="4" rx="1" ry="1"></rect>
+        </svg>
+    </a>
+  
+</div>
+        <div class="clear"></div>
+      </div>
+
+      <div id="content"><h1>Resource Type: selinux_permissive</h1>
+<div class="box_info">
+  <dl>
+    <dt>Defined in:</dt>
+    <dd>
+      lib/puppet/type/selinux_permissive.rb
+    </dd>
+  </dl>
+  
+  <dl>
+    <dt>Providers:</dt>
+    <dd>
+      
+        <span class='object_link'><a href="../puppet_providers_selinux_permissive/semanage.html" title="puppet_providers_selinux_permissive::semanage (puppet_provider)">semanage</a></span><br/>
+      
+    </dd>
+  </dl>
+  
+</div>
+<h2>Overview</h2>
+<div class="docstring">
+  <div class="discussion">
+    <p>Manage SELinux permissive types.</p>
+
+  </div>
+</div>
+<div class="tags">
+  
+
+</div>
+<div class="tags">
+  <p class="tag_title">Properties</p>
+  <ul>
+    
+    <li>
+      <span class="name">ensure</span>
+      
+      <span class="default"> (defaults to: <em>present</em>)</span>
+      
+      
+      <div class="docstring">
+        <div class="discussion">
+          <p>The basic property that the resource should be in.</p>
+
+        </div>
+      </div>
+      
+      
+      <div>
+        Supported values:
+        <ul>
+          
+          <li>
+            
+            present
+          </li>
+          
+          <li>
+            
+            absent
+          </li>
+          
+        </ul>
+      </div>
+      
+    </li>
+    
+  </ul>
+</div>
+
+
+<div class="tags">
+  <p class="tag_title">Parameters</p>
+  <ul>
+    
+    <li>
+      <span class="name">local</span>
+      
+      
+      <div class="docstring">
+        <div class="discussion">
+          <p>A read-only attribue indicating whether the type is locally customized</p>
+
+        </div>
+      </div>
+      
+      
+      <div>
+        Supported values:
+        <ul>
+          
+          <li>
+            
+            true
+          </li>
+          
+          <li>
+            
+            false
+          </li>
+          
+        </ul>
+      </div>
+      
+    </li>
+    
+    <li>
+      <span class="name">seltype (namevar)</span>
+      
+      
+      <div class="docstring">
+        <div class="discussion">
+          <p>The SELinux type that should be permissive</p>
+
+        </div>
+      </div>
+      
+      
+    </li>
+    
+  </ul>
+</div>
+
+
+</div>
+
+      <div id="footer">
+  Generated on Tue Jan 31 20:51:44 2017 by
+  <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
+  0.9.8 (ruby-2.3.3).
+</div>
+
+    </div>
+  </body>
+</html>

--- a/docs/puppet_types/selinux_port.html
+++ b/docs/puppet_types/selinux_port.html
@@ -1,0 +1,269 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>
+  Resource Type: selinux_port
+  
+    &mdash; Documentation by YARD 0.9.8
+  
+</title>
+
+  <link rel="stylesheet" href="../css/style.css" type="text/css" charset="utf-8" />
+
+  <link rel="stylesheet" href="../css/common.css" type="text/css" charset="utf-8" />
+
+<script type="text/javascript" charset="utf-8">
+  pathId = "puppet_types::selinux_port";
+  relpath = '../';
+</script>
+
+
+  <script type="text/javascript" charset="utf-8" src="../js/jquery.js"></script>
+
+  <script type="text/javascript" charset="utf-8" src="../js/app.js"></script>
+
+
+  </head>
+  <body>
+    <div class="nav_wrap">
+      <iframe id="nav" src="../puppet_type_list.html?1"></iframe>
+      <div id="resizer"></div>
+    </div>
+
+    <div id="main" tabindex="-1">
+      <div id="header">
+        <div id="menu">
+  
+    <a href="../_index.html">Index (s)</a> &raquo;
+    <span class='title'><span class='object_link'>Resource Types</span></span>
+     &raquo; 
+    <span class="title">selinux_port</span>
+  
+</div>
+
+        <div id="search">
+  
+    <a class="full_list_link" id="puppet_class_list_link"
+        href="../puppet_class_list.html">
+
+        <svg width="24" height="24">
+          <rect x="0" y="4" width="24" height="4" rx="1" ry="1"></rect>
+          <rect x="0" y="12" width="24" height="4" rx="1" ry="1"></rect>
+          <rect x="0" y="20" width="24" height="4" rx="1" ry="1"></rect>
+        </svg>
+    </a>
+  
+</div>
+        <div class="clear"></div>
+      </div>
+
+      <div id="content"><h1>Resource Type: selinux_port</h1>
+<div class="box_info">
+  <dl>
+    <dt>Defined in:</dt>
+    <dd>
+      lib/puppet/type/selinux_port.rb
+    </dd>
+  </dl>
+  
+  <dl>
+    <dt>Providers:</dt>
+    <dd>
+      
+        <span class='object_link'><a href="../puppet_providers_selinux_port/semanage.html" title="puppet_providers_selinux_port::semanage (puppet_provider)">semanage</a></span><br/>
+      
+    </dd>
+  </dl>
+  
+</div>
+<h2>Overview</h2>
+<div class="docstring">
+  <div class="discussion">
+    <p>Manage SELinux port definitions. You should use selinux::port instead of this directly.</p>
+
+  </div>
+</div>
+<div class="tags">
+  
+
+</div>
+<div class="tags">
+  <p class="tag_title">Properties</p>
+  <ul>
+    
+    <li>
+      <span class="name">ensure</span>
+      
+      <span class="default"> (defaults to: <em>present</em>)</span>
+      
+      
+      <div class="docstring">
+        <div class="discussion">
+          <p>The basic property that the resource should be in.</p>
+
+        </div>
+      </div>
+      
+      
+      <div>
+        Supported values:
+        <ul>
+          
+          <li>
+            
+            present
+          </li>
+          
+          <li>
+            
+            absent
+          </li>
+          
+        </ul>
+      </div>
+      
+    </li>
+    
+    <li>
+      <span class="name">high_port</span>
+      
+      
+      <div class="docstring">
+        <div class="discussion">
+          <p>The high end of the port range to manage</p>
+
+        </div>
+      </div>
+      
+      
+    </li>
+    
+    <li>
+      <span class="name">low_port</span>
+      
+      
+      <div class="docstring">
+        <div class="discussion">
+          <p>The low end of the port range to manage</p>
+
+        </div>
+      </div>
+      
+      
+    </li>
+    
+    <li>
+      <span class="name">protocol</span>
+      
+      
+      <div class="docstring">
+        <div class="discussion">
+          <p>The protocol of the SELinux port definition</p>
+
+        </div>
+      </div>
+      
+      
+      <div>
+        Supported values:
+        <ul>
+          
+          <li>
+            
+            tcp
+          </li>
+          
+          <li>
+            
+            udp
+          </li>
+          
+        </ul>
+      </div>
+      
+    </li>
+    
+    <li>
+      <span class="name">seltype</span>
+      
+      
+      <div class="docstring">
+        <div class="discussion">
+          <p>The SELinux type of the SELinux port definition</p>
+
+        </div>
+      </div>
+      
+      
+    </li>
+    
+    <li>
+      <span class="name">source</span>
+      
+      
+      <div class="docstring">
+        <div class="discussion">
+          <p>Source of the port configuration - either policy or local</p>
+
+        </div>
+      </div>
+      
+      
+      <div>
+        Supported values:
+        <ul>
+          
+          <li>
+            
+            policy
+          </li>
+          
+          <li>
+            
+            local
+          </li>
+          
+        </ul>
+      </div>
+      
+    </li>
+    
+  </ul>
+</div>
+
+
+<div class="tags">
+  <p class="tag_title">Parameters</p>
+  <ul>
+    
+    <li>
+      <span class="name">title</span>
+      
+      
+      <div class="docstring">
+        <div class="discussion">
+          <p>Should be of the form &quot;protocol_lowport-highport&quot; or the type may misbehave</p>
+
+        </div>
+      </div>
+      
+      
+    </li>
+    
+  </ul>
+</div>
+
+
+</div>
+
+      <div id="footer">
+  Generated on Tue Jan 31 20:51:44 2017 by
+  <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
+  0.9.8 (ruby-2.3.3).
+</div>
+
+    </div>
+  </body>
+</html>

--- a/docs/top-level-namespace.html
+++ b/docs/top-level-namespace.html
@@ -6,7 +6,7 @@
 <title>
   Top Level Namespace
   
-    &mdash; Documentation by YARD 0.9.7
+    &mdash; Documentation by YARD 0.9.8
   
 </title>
 
@@ -90,9 +90,9 @@
 </div>
 
       <div id="footer">
-  Generated on Fri Jan 13 15:43:22 2017 by
+  Generated on Tue Jan 31 20:51:44 2017 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
-  0.9.7 (ruby-2.3.3).
+  0.9.8 (ruby-2.3.3).
 </div>
 
     </div>

--- a/lib/puppet/type/selinux_port.rb
+++ b/lib/puppet/type/selinux_port.rb
@@ -42,6 +42,7 @@ Puppet::Type.newtype(:selinux_port) do
   end
 
   newproperty(:source) do
+    desc 'Source of the port configuration - either policy or local'
     newvalues(:policy, :local)
 
     validate do |_value|

--- a/manifests/fcontext.pp
+++ b/manifests/fcontext.pp
@@ -17,6 +17,7 @@
 #
 # @param ensure   The desired state of the resource. Default: 'present'
 # @param seltype  String A particular SELinux type, like "mysqld_log_t"
+# @param seluser  String A particular SELinux user, like "sysadm_u"
 # @param pathspec String An semanage fcontext-formatted path specification, 
 #                        like "/var/log/mysql(/.*)?". Defaults to title
 # @param filetype File type the context applies to (i.e. regular file, directory, block device, all files, etc.)

--- a/manifests/permissive.pp
+++ b/manifests/permissive.pp
@@ -2,6 +2,7 @@
 #
 # This define will set an SELinux type to permissive
 #
+# @param ensure Set to present to add or absent to remove a permissive mode of a type
 # @param seltype A particular selinux type to make permissive, like "oddjob_mkhomedir_t"
 #
 # @example Mark oddjob_mkhomedir_t permissive

--- a/manifests/port.pp
+++ b/manifests/port.pp
@@ -11,10 +11,11 @@
 #     port     => 8514,
 #   }
 #
+# @param ensure Set to present to add or absent to remove a port context.
 # @param seltype An SELinux port type
 # @param protocol Either 'tcp', 'udp', 'ipv4' or 'ipv6'
 # @param port A network port number, like 8514,
-# @param port_rage A port-range tuple, eg. [9090, 9095].
+# @param port_range A port-range tuple, eg. [9090, 9095].
 #
 define selinux::port (
   String                             $seltype,

--- a/spec/acceptance/nodesets/centos-6-x64.yml
+++ b/spec/acceptance/nodesets/centos-6-x64.yml
@@ -1,0 +1,15 @@
+---
+# This file is managed via modulesync
+# https://github.com/voxpupuli/modulesync
+# https://github.com/voxpupuli/modulesync_config
+HOSTS:
+  centos-6-x64:
+    roles:
+      - master
+    platform: el-6-x86_64
+    box: centos/6
+    hypervisor: vagrant
+CONFIG:
+  type: aio
+...
+# vim: syntax=yaml

--- a/spec/acceptance/nodesets/centos-7-x64.yml
+++ b/spec/acceptance/nodesets/centos-7-x64.yml
@@ -1,0 +1,15 @@
+---
+# This file is managed via modulesync
+# https://github.com/voxpupuli/modulesync
+# https://github.com/voxpupuli/modulesync_config
+HOSTS:
+  centos-7-x64:
+    roles:
+      - master
+    platform: el-7-x86_64
+    box: centos/7
+    hypervisor: vagrant
+CONFIG:
+  type: aio
+...
+# vim: syntax=yaml


### PR DESCRIPTION
Puppet 3.8.7 was specified in README.md but this is now Puppet 4 only.
