### PR TITLE
Remove support for EL5 and Fedora < 24

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -11,7 +11,6 @@
     {
       "operatingsystem": "RedHat",
       "operatingsystemrelease": [
-        "5",
         "6",
         "7"
       ]
@@ -19,18 +18,13 @@
     {
       "operatingsystem": "Fedora",
       "operatingsystemrelease": [
-        "19",
-        "20",
-        "21",
-        "22",
-        "23",
-        "24"
+        "24",
+        "25"
       ]
     },
     {
       "operatingsystem": "Amazon",
       "operatingsystemrelease": [
-        "5.0",
         "6.0",
         "7.0"
       ]


### PR DESCRIPTION
We only can run acceptance tests against supported upstream distros.

Right now our acceptance tests run on:

* CentOS 6, 7 (compatible with RHEL 6, 7)
* Fedora 24, 25

The module stated support for CentOS 5 but actually it didn't work.

Closes #190