### PR TITLE
Remove Amazon Linux support

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -39,17 +39,6 @@ class selinux::params {
             }
           }
         }
-        'Amazon': {
-          $sx_fs_mount = '/selinux'
-          case $os_maj_release {
-            '4': {
-              $package_name = 'policycoreutils-python'
-            }
-            default: {
-              fail("${::operatingsystem}-${::os_maj_release} is not supported")
-            }
-          }
-        }
         default: {
           case $os_maj_release {
             '7': {

--- a/metadata.json
+++ b/metadata.json
@@ -21,13 +21,6 @@
         "24",
         "25"
       ]
-    },
-    {
-      "operatingsystem": "Amazon",
-      "operatingsystemrelease": [
-        "6.0",
-        "7.0"
-      ]
     }
   ],
   "dependencies": [


### PR DESCRIPTION
We don't have the ability to test Amazone Linux. Amazon Linux
is similiar to CentOS or RHEL but it's not the same.

We only list systems we test with beaker acceptance tests
as supported.