### PR TITLE
Convert selinux::boolean to puppet types

### DIFF
--- a/manifests/boolean.pp
+++ b/manifests/boolean.pp
@@ -4,20 +4,20 @@
 #
 # @example Enable `named_write_master_zones`  boolean
 #   selinux::boolean{ 'named_write_master_zones':
-#      ensure     => "on",
+#      ensure     => 'on',
 #   }
 #
 # @example Ensure `named_write_master_zones` boolean is disabled
 #   selinux::boolean{ 'named_write_master_zones':
-#      ensure     => "off",
+#      ensure     => 'off',
 #   }
 #
 # @param ensure Set to on or off
 # @param persistent Set to false if you don't want it to survive a reboot.
 #
 define selinux::boolean (
-  $ensure     = 'on',
-  $persistent = true,
+  Variant[Boolean, Enum['on', 'off', 'present', 'absent']] $ensure = 'on',
+  Boolean $persistent = true,
 ) {
 
   include ::selinux
@@ -27,18 +27,15 @@ define selinux::boolean (
   Anchor['selinux::end']
 
   $ensure_real = $ensure ? {
-    true    => 'true', # lint:ignore:quoted_booleans
-    false   => 'false', # lint:ignore:quoted_booleans
+    true    => 'on',
+    false   => 'off',
     default => $ensure,
   }
 
-  validate_re($ensure_real, ['^on$', '^true$', '^present$', '^off$', '^false$', '^absent$'], 'Valid ensures must be one of on, true, present, off, false, or absent')
-  validate_bool($persistent)
-
   $value = $ensure_real ? {
-    /(?i-mx:on|true|present)/  => 'on',
-    /(?i-mx:off|false|absent)/ => 'off',
-    default                    => undef,
+    /(?i-mx:on|present)/ => 'on',
+    /(?i-mx:off|absent)/ => 'off',
+    default              => undef,
   }
 
   selboolean { $name:


### PR DESCRIPTION
Small PR to add types to the selinux::boolean define

I thought about typefying the restorecond manifest too, but I'm wondering if it should just be removed... It doesn't seem very useful as it is.

