### PR TITLE
Add a convenience wrapper for restorecon execs

### DIFF
--- a/manifests/exec_restorecon.pp
+++ b/manifests/exec_restorecon.pp
@@ -1,0 +1,37 @@
+# selinux::exec_restorecon
+# 
+# A convenience wrapper around a restorecon exec
+#
+# Will execute after all other SELinux changes have been applied, but before
+# Anchor['selinux::end']
+# 
+# @param path The path to run restorecon on. Defaults to resource title.
+# @param recurse Whether restorecon should recurse. Defaults to true
+# @param refreshonly see the Exec resource
+# @param unless see the Exec resource
+# @param onlyif see the Exec resource
+#
+define selinux::exec_restorecon(
+  Stdlib::Absolutepath $path        = $title,
+  Boolean              $refreshonly = true,
+  Boolean              $recurse     = true,
+  Optional[String]     $unless      = undef,
+  Optional[String]     $onlyif      = undef,
+) {
+  include ::selinux
+  $command = $recurse ? {
+    true  => 'restorecon -R',
+    false => 'restorecon',
+  }
+
+  exec {"selinux::exec_restorecon ${path}":
+    path        => '/sbin:/usr/sbin',
+    command     => sprintf('%s %s', $command, shellquote($path)),
+    refreshonly => $refreshonly,
+    unless      => $unless,
+    onlyif      => $onlyif,
+    before      => Anchor['selinux::end'],
+  }
+
+  Anchor['selinux::module post']  -> Exec["selinux::exec_restorecon ${path}"]
+}

--- a/spec/defines/selinux_exec_restorecon_spec.rb
+++ b/spec/defines/selinux_exec_restorecon_spec.rb
@@ -1,0 +1,45 @@
+require 'spec_helper'
+
+describe 'selinux::exec_restorecon' do
+  on_supported_os.each do |os, _facts|
+    context "on #{os}" do
+      context 'with resource titled /opt/mycustompath' do
+        let(:title) { '/opt/mycustompath' }
+        context 'with defaults' do
+          it { is_expected.to contain_exec('selinux::exec_restorecon /opt/mycustompath').with(command: 'restorecon -R /opt/mycustompath', refreshonly: true) }
+        end
+        context 'without recursion' do
+          let(:params) { { recurse: false } }
+          it { is_expected.to contain_exec('selinux::exec_restorecon /opt/mycustompath').with(command: 'restorecon /opt/mycustompath') }
+        end
+        context 'ordering' do
+          it { is_expected.to contain_exec('selinux::exec_restorecon /opt/mycustompath').that_comes_before('Anchor[selinux::end]') }
+          it { is_expected.to contain_anchor('selinux::module post').that_comes_before('Exec[selinux::exec_restorecon /opt/mycustompath]') }
+        end
+        context 'with optional parameters' do
+          let(:params) { { onlyif: 'some_command', unless: 'some_other_command', refreshonly: false } }
+          it do
+            is_expected.to contain_exec('selinux::exec_restorecon /opt/mycustompath').with(
+              onlyif: 'some_command',
+              unless: 'some_other_command',
+              refreshonly: false
+            )
+          end
+        end
+      end
+      context 'with resource titled /opt/$HOME/some weird dir/' do
+        let(:title) { '/opt/$HOME/some weird dir/' }
+        context 'with defaults' do
+          it { is_expected.to contain_exec('selinux::exec_restorecon /opt/$HOME/some weird dir/').with(command: "restorecon -R '/opt/$HOME/some weird dir/'", refreshonly: true) }
+        end
+      end
+      context 'with path /weird/\'pa th\'/"quotes"' do
+        let(:title) { 'just_for_testing' }
+        let(:params) { { path: %q(/weird/'pa th'/"quotes") } }
+        context 'with defaults' do
+          it { is_expected.to contain_exec(%q(selinux::exec_restorecon /weird/'pa th'/"quotes")).with(command: %q(restorecon -R "/weird/'pa th'/\"quotes\""), refreshonly: true) }
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This wraps a restorecon exec so that it will execute after all other SELinux changes have been applied

Not yet very thorougly tested (or integrated with the fcontext define) but it should be useful enough standalone. Any comments?
