### PR TITLE
Make use of the stdlib puppet_vardir fact instead of a custom one

### DIFF
--- a/lib/facter/selinux_agent_vardir.rb
+++ b/lib/facter/selinux_agent_vardir.rb
@@ -1,6 +1,0 @@
-require 'puppet'
-Facter.add(:selinux_agent_vardir) do
-  setcode do
-    Puppet.settings['vardir']
-  end
-end

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -13,7 +13,7 @@ class selinux::params {
 
   $refpolicy_package_name = 'selinux-policy-devel'
 
-  $module_build_root = "${::selinux_agent_vardir}/puppet-selinux"
+  $module_build_root = "${facts['puppet_vardir']}/puppet-selinux"
 
   if $::operatingsystemmajrelease {
     $os_maj_release = $::operatingsystemmajrelease

--- a/spec/default_module_facts.yml
+++ b/spec/default_module_facts.yml
@@ -5,5 +5,4 @@ operatingsystemmajrelease: '7'
 # concat facts
 id: 0
 path: /tmp
-# custom fact for module building:
-selinux_agent_vardir: /var/lib/puppet
+puppet_vardir: /var/lib/puppet


### PR DESCRIPTION
Turns out this already existed, so our custom implementation in the module is not necessary.

I don't consider this a breaking change, since the fact is an implementation detail.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
