### PR TITLE
Fedora 26 uses the same package_name as Fedora 25

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -34,7 +34,7 @@ class selinux::params {
             '21','22','23' : {
               $package_name = 'policycoreutils-devel'
             }
-            '24', '25' : {
+            '24','25','26' : {
               $package_name = 'policycoreutils-python-utils'
             }
             default: {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -34,11 +34,8 @@ class selinux::params {
             '21','22','23' : {
               $package_name = 'policycoreutils-devel'
             }
-            '24','25','26' : {
-              $package_name = 'policycoreutils-python-utils'
-            }
             default: {
-              fail("${::operatingsystem}-${::os_maj_release} is not supported")
+              $package_name = 'policycoreutils-python-utils'
             }
           }
         }


### PR DESCRIPTION
Fedora 26 is almost upon us (it's available today as an alpha release), and it uses the same package name as Fedora 25.