### PR TITLE
(WIP) Test Fedora 26

### DIFF
--- a/spec/acceptance/nodesets/fedora-26-x64.yml
+++ b/spec/acceptance/nodesets/fedora-26-x64.yml
@@ -1,0 +1,21 @@
+---
+# This file is managed via modulesync
+# https://github.com/voxpupuli/modulesync
+# https://github.com/voxpupuli/modulesync_config
+#
+# platform is fedora 24 because there is no
+# puppet-agent for fedora 25 by 2016-12-30
+HOSTS:
+  fedora-26-x64:
+    roles:
+      - master
+    platform: fedora-25-x86_64
+    # by url doesn't work - path will get too long
+    # https://apps.fedoraproject.org/autocloud/compose ->
+    # https://kojipkgs.fedoraproject.org/compose/rawhide/Fedora-Rawhide-20170522.n.0/compose/CloudImages/x86_64/images/
+    box: /tmp/Fedora-Cloud-Base-Vagrant-Rawhide-20170522.n.0.x86_64.vagrant-virtualbox.box
+    hypervisor: vagrant
+CONFIG:
+  type: aio
+...
+# vim: syntax=yaml


### PR DESCRIPTION
Added a Fedora Rawhide box to test upcoming Fedora 26.

One test fails. looks like some python issue.

```
Failures:

  1) selinux::permissive define purge with ensure present for passwd_t, when kernel_t is permissive runs without errors
     Failure/Error: apply_manifest(manifest, catch_failures: true)
     Beaker::Host::CommandFailure:
       Host 'fedora-26-x64' exited with 6 running:
        puppet apply --verbose --detailed-exitcodes /tmp/apply_manifest.pp.TKHual
       Last 10 lines of output were:
        libsemanage.semanage_direct_remove_key: Unable to remove module permissive_Python at priority 400. (No such file or directory).
        FileNotFoundError: [Errno 2] No such file or directory
        Error: /Stage[main]/Main/Selinux_permissive[Python runtime initialized with LC_CTYPE=C (a locale with default ASCII encoding), which may cause Unicode compatibility problems. Using C.UTF-8, C.utf8, or UTF-8 (if available) as alternative Unicode-compatible locales is recommended.]/ensure: change from present to absent failed: Execution of '/usr/sbin/semanage permissive -d Python runtime initialized with LC_CTYPE=C (a locale with default ASCII encoding), which may cause Unicode compatibility problems. Using C.UTF-8, C.utf8, or UTF-8 (if available) as alternative Unicode-compatible locales is recommended.' returned 1: Python runtime initialized with LC_CTYPE=C (a locale with default ASCII encoding), which may cause Unicode compatibility problems. Using C.UTF-8, C.utf8, or UTF-8 (if available) as alternative Unicode-compatible locales is recommended.
        libsemanage.semanage_direct_remove_key: Unable to remove module permissive_Python at priority 400. (No such file or directory).
        FileNotFoundError: [Errno 2] No such file or directory
        Notice: /Stage[main]/Main/Selinux_permissive[kernel_t]/ensure: removed
        Notice: /Stage[main]/Main/Selinux_permissive[puppet_selinux_test_policy_t]/ensure: removed
        Notice: /Stage[main]/Main/Selinux::Permissive[passwd_t]/Selinux_permissive[passwd_t]/ensure: created
        Info: Class[Main]: Unscheduling all events on Class[Main]
        Notice: Applied catalog in 23.17 seconds
     # /home/user/.gem/ruby/gems/beaker-3.16.0/lib/beaker/host.rb:373:in `exec'
     # /home/user/.gem/ruby/gems/beaker-3.16.0/lib/beaker/dsl/helpers/host_helpers.rb:83:in `block in on'
     # /home/user/.gem/ruby/gems/beaker-3.16.0/lib/beaker/shared/host_manager.rb:127:in `run_block_on'
     # /home/user/.gem/ruby/gems/beaker-3.16.0/lib/beaker/dsl/patterns.rb:37:in `block_on'
     # /home/user/.gem/ruby/gems/beaker-3.16.0/lib/beaker/dsl/helpers/host_helpers.rb:63:in `on'
     # /home/user/.gem/ruby/gems/beaker-3.16.0/lib/beaker/dsl/helpers/puppet_helpers.rb:504:in `block in apply_manifest_on'
     # /home/user/.gem/ruby/gems/beaker-3.16.0/lib/beaker/shared/host_manager.rb:127:in `run_block_on'
     # /home/user/.gem/ruby/gems/beaker-3.16.0/lib/beaker/dsl/patterns.rb:37:in `block_on'
     # /home/user/.gem/ruby/gems/beaker-3.16.0/lib/beaker/dsl/helpers/puppet_helpers.rb:433:in `apply_manifest_on'
     # /home/user/.gem/ruby/gems/beaker-3.16.0/lib/beaker/dsl/helpers/puppet_helpers.rb:511:in `apply_manifest'
     # ./spec/acceptance/selinux_permissive_spec.rb:30:in `block (3 levels) in <top (required)>'
     # ./spec/acceptance/selinux_permissive_spec.rb:39:in `block (3 levels) in <top (required)>'

Finished in 4 minutes 4.4 seconds (files took 2 minutes 0.4 seconds to load)
23 examples, 1 failure
```