### PR TITLE
puppet3 module fixes

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -78,7 +78,7 @@ class selinux::config (
     if $mode == 'disabled' {
       exec { "change-selinux-status-to-${mode}":
         command => "setenforce ${sestatus}",
-        unless  => "getenforce | grep -Eqi 'permissive'",
+        unless  => "getenforce | grep -Eqi 'permissive|disabled'",
         path    => '/bin:/sbin:/usr/bin:/usr/sbin',
       }
     } else {

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -69,12 +69,24 @@ class selinux::config (
         group   => 'root',
         content => "# created by puppet for disabled to ${mode} switch\n",
       }
+    } else {
+      file { '/.autorelabel':
+        ensure => absent,
+      }
     }
 
-    exec { "change-selinux-status-to-${mode}":
-      command => "setenforce ${sestatus}",
-      unless  => "getenforce | grep -Eqi '${mode}|disabled'",
-      path    => '/bin:/sbin:/usr/bin:/usr/sbin',
+    if $mode == 'disabled' {
+      exec { "change-selinux-status-to-${mode}":
+        command => "setenforce ${sestatus}",
+        unless  => "getenforce | grep -Eqi 'permissive'",
+        path    => '/bin:/sbin:/usr/bin:/usr/sbin',
+      }
+    } else {
+      exec { "change-selinux-status-to-${mode}":
+        command => "setenforce ${sestatus}",
+        unless  => "getenforce | grep -Eqi '${mode}|disabled'",
+        path    => '/bin:/sbin:/usr/bin:/usr/sbin',
+      }
     }
   }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -60,7 +60,7 @@ class selinux (
 
   validate_absolute_path($sx_mod_dir)
   validate_re($mode_real, ['^enforcing$', '^permissive$', '^disabled$', '^undef$'], "Valid modes are enforcing, permissive, and disabled.  Received: ${mode}")
-  validate_re($type_real, ['^targeted$', '^minimum$', '^mls$', '^undef$'], "Valid types are targeted, minimum, and mls.  Received: ${type}")
+  validate_re($type_real, ['^strict$', '^targeted$', '^minimum$', '^mls$', '^undef$'], "Valid types are strict, targeted, minimum, and mls.  Received: ${type}")
   validate_string($makefile)
   validate_bool($manage_package)
   validate_string($package_name)

--- a/spec/classes/selinux_config_type_spec.rb
+++ b/spec/classes/selinux_config_type_spec.rb
@@ -20,6 +20,13 @@ describe 'selinux' do
           it { is_expected.not_to contain_file_line('set-selinux-config-type-to-minimum') }
           it { is_expected.not_to contain_file_line('set-selinux-config-type-to-mls') }
         end
+
+        context 'strict' do
+          let(:params) { { type: 'strict' } }
+
+          it { is_expected.to contain_file('/usr/share/selinux').with(ensure: 'directory') }
+          it { is_expected.to contain_file_line('set-selinux-config-type-to-strict').with(line: 'SELINUXTYPE=strict') }
+        end
         context 'targeted' do
           let(:params) { { type: 'targeted' } }
 


### PR DESCRIPTION
Hi

A few fixes for selinux module:
1. Added strict mode for centos 5/6 policy
2. Fixed the case when selinux was in permissive but is set to disabled, that causes puppet try to do setenforce 0 again and again until reboot.