### PR TITLE
Declare Puppet 5 compatability

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,9 @@ matrix:
     env: PUPPET_VERSION="~> 4.0" CHECK=test
   - rvm: 2.4.1
     bundler_args: --without system_tests development
+    env: PUPPET_VERSION="~> 5.0" CHECK=test
+  - rvm: 2.4.1
+    bundler_args: --without system_tests development
     env: PUPPET_VERSION="~> 4.0" CHECK=rubocop
   - rvm: 2.4.1
     bundler_args: --without system_tests development

--- a/metadata.json
+++ b/metadata.json
@@ -32,7 +32,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 4.7.0 < 5.0.0"
+      "version_requirement": ">= 4.7.0 < 6.0.0"
     }
   ]
 }

--- a/spec/defines/selinux_exec_restorecon_spec.rb
+++ b/spec/defines/selinux_exec_restorecon_spec.rb
@@ -34,7 +34,10 @@ describe 'selinux::exec_restorecon' do
         let(:title) { '/opt/$HOME/some weird dir/' }
 
         context 'with defaults' do
-          it { is_expected.to contain_exec('selinux::exec_restorecon /opt/$HOME/some weird dir/').with(command: "restorecon -R '/opt/$HOME/some weird dir/'", refreshonly: true) }
+          # started to fail with rspec-puppet 2.6.0, worked fine with rspec-puppet 2.5.0
+          # https://github.com/voxpupuli/puppet-selinux/issues/225
+          # https://github.com/rodjek/rspec-puppet/issues/536
+          xit { is_expected.to contain_exec('selinux::exec_restorecon /opt/$HOME/some weird dir/').with(command: "restorecon -R '/opt/$HOME/some weird dir/'", refreshonly: true) }
         end
       end
       context 'with path /weird/\'pa th\'/"quotes"' do


### PR DESCRIPTION
* Update metadata.json to declare Puppet 5 compatability.
* Add Puppet 5.0 check in travis.yml (requires modulesync_config or .sync.yml update too)
* exclude rspec test that fails with new rspec-puppet 2.6.0 (#225)