### PR TITLE
Add Amazon Linux support

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -39,6 +39,10 @@ class selinux::params {
             }
           }
         }
+        'Amazon': {
+          $sx_fs_mount = '/selinux'
+          $package_name = 'policycoreutils'
+        }
         default: {
           case $os_maj_release {
             '7': {


### PR DESCRIPTION
In the case of SELinux, Amazon Linux appears to resemble RHEL 5.
This allows the module to compile, rather than choke, on Amazon
Linux 2017.03.

Closes: #230 