### PR TITLE
Add exec_restorecon to hiera calls

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -1,0 +1,14 @@
+---
+lookup_options:
+  selinux::boolean:
+    merge: hash
+  selinux::fcontext:
+    merge: hash
+  selinux::module:
+    merge: hash
+  selinux::permissive:
+    merge: hash
+  selinux::port:
+    merge: hash
+  selinux::exec_restorecon:
+    merge: hash

--- a/hiera.yaml
+++ b/hiera.yaml
@@ -1,0 +1,6 @@
+---
+version: 5
+
+hierarchy:
+  - name: "common"
+    path: "common.yaml"

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -44,11 +44,12 @@ class selinux (
   Enum['refpolicy', 'simple'] $default_builder                = 'simple',
 
   ### START Hiera Lookups ###
-  $boolean        = undef,
-  $fcontext       = undef,
-  $module         = undef,
-  $permissive     = undef,
-  $port           = undef,
+  Optional[Hash] $boolean         = lookup('selinux::boolean',         { 'default_value' => undef, 'merge' => 'hash' }),
+  Optional[Hash] $fcontext        = lookup('selinux::fcontext',        { 'default_value' => undef, 'merge' => 'hash' }),
+  Optional[Hash] $module          = lookup('selinux::module',          { 'default_value' => undef, 'merge' => 'hash' }),
+  Optional[Hash] $permissive      = lookup('selinux::permissive',      { 'default_value' => undef, 'merge' => 'hash' }),
+  Optional[Hash] $port            = lookup('selinux::port',            { 'default_value' => undef, 'merge' => 'hash' }),
+  Optional[Hash] $exec_restorecon = lookup('selinux::exec_restorecon', { 'default_value' => undef, 'merge' => 'hash' }),
   ### END Hiera Lookups ###
 
 ) inherits selinux::params {
@@ -61,19 +62,22 @@ class selinux (
   class { '::selinux::config': }
 
   if $boolean {
-    create_resources ( 'selinux::boolean', hiera_hash('selinux::boolean', $boolean) )
+    create_resources ( 'selinux::boolean', $boolean )
   }
   if $fcontext {
-    create_resources ( 'selinux::fcontext', hiera_hash('selinux::fcontext', $fcontext) )
+    create_resources ( 'selinux::fcontext', $fcontext )
   }
   if $module {
-    create_resources ( 'selinux::module', hiera_hash('selinux::module', $module) )
+    create_resources ( 'selinux::module', $module )
   }
   if $permissive {
-    create_resources ( 'selinux::permissive', hiera_hash('selinux::permissive', $permissive) )
+    create_resources ( 'selinux::permissive', $permissive )
   }
   if $port {
-    create_resources ( 'selinux::port', hiera_hash('selinux::port', $port) )
+    create_resources ( 'selinux::port', $port )
+  }
+  if $exec_restorecon {
+    create_resources ( 'selinux::exec_restorecon', $exec_restorecon )
   }
 
   # Ordering

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -44,12 +44,12 @@ class selinux (
   Enum['refpolicy', 'simple'] $default_builder                = 'simple',
 
   ### START Hiera Lookups ###
-  Optional[Hash] $boolean         = lookup('selinux::boolean',         { 'default_value' => undef, 'merge' => 'hash' }),
-  Optional[Hash] $fcontext        = lookup('selinux::fcontext',        { 'default_value' => undef, 'merge' => 'hash' }),
-  Optional[Hash] $module          = lookup('selinux::module',          { 'default_value' => undef, 'merge' => 'hash' }),
-  Optional[Hash] $permissive      = lookup('selinux::permissive',      { 'default_value' => undef, 'merge' => 'hash' }),
-  Optional[Hash] $port            = lookup('selinux::port',            { 'default_value' => undef, 'merge' => 'hash' }),
-  Optional[Hash] $exec_restorecon = lookup('selinux::exec_restorecon', { 'default_value' => undef, 'merge' => 'hash' }),
+  Optional[Hash] $boolean         = undef,
+  Optional[Hash] $fcontext        = undef,
+  Optional[Hash] $module          = undef,
+  Optional[Hash] $permissive      = undef,
+  Optional[Hash] $port            = undef,
+  Optional[Hash] $exec_restorecon = undef,
   ### END Hiera Lookups ###
 
 ) inherits selinux::params {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -32,6 +32,7 @@
 # @param module Hash of selinux::module resource parameters
 # @param permissive Hash of selinux::module resource parameters
 # @param port Hash of selinux::port resource parameters
+# @param exec_restorecon Hash of selinux::exec_restorecon resource parameters
 #
 class selinux (
   Optional[Enum['enforcing', 'permissive', 'disabled']] $mode = $::selinux::params::mode,


### PR DESCRIPTION
Also add type definitions for hiera values and replace hiera_hash with the new lookup variant (fixing #238)

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
