### PR TITLE
Fixing change-selinux-status-to-disabled exec

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -80,10 +80,13 @@ class selinux::config (
       }
     }
 
-    exec { "change-selinux-status-to-${_real_mode}":
-      command => "setenforce ${sestatus}",
-      unless  => "getenforce | grep -Eqi '${_real_mode}|disabled'",
-      path    => '/bin:/sbin:/usr/bin:/usr/sbin',
+    # setenforce only works when SELinux itself is enabled
+    if $_real_mode in ['enforcing','permissive'] {
+      exec { "change-selinux-status-to-${_real_mode}":
+        command => "setenforce ${sestatus}",
+        unless  => "getenforce | grep -Eqi '${_real_mode}|disabled'",
+        path    => '/bin:/sbin:/usr/bin:/usr/sbin',
+      }
     }
   }
 

--- a/spec/classes/selinux_config_mode_spec.rb
+++ b/spec/classes/selinux_config_mode_spec.rb
@@ -59,7 +59,6 @@ describe 'selinux' do
 
           it { is_expected.to contain_file('/var/lib/puppet/puppet-selinux') }
           it { is_expected.to contain_file_line('set-selinux-config-to-disabled').with(line: 'SELINUX=disabled') }
-          it { is_expected.to contain_exec('change-selinux-status-to-disabled').with(command: 'setenforce 0') }
           it { is_expected.not_to contain_file('/.autorelabel') }
         end
 


### PR DESCRIPTION
setenforce only accepts enforcing or permissive (or 0 and 1) as possible modes.
When calling the selinux module with the current mode as either enforcing or permissive and $mode => disabled, the exec change-selinux-status-to-disabled will give exit code 1. A reboot does solve this, but until that happens. each puppet run will result in a report with a corrective change.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
