### PR TITLE
Update and check runtime SELinux status correcty

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -55,13 +55,13 @@ class selinux::config (
 
     case $_real_mode {
       'permissive', 'disabled': {
-        $sestatus = '0'
+        $sestatus = 'permissive'
         if $_real_mode == 'disabled' and defined('$::selinux_current_mode') and $::selinux_current_mode == 'permissive' {
           notice('A reboot is required to fully disable SELinux. SELinux will operate in Permissive mode until a reboot')
         }
       }
       'enforcing': {
-        $sestatus = '1'
+        $sestatus = 'enforcing'
       }
       default : {
         fail('You must specify a mode (enforced, permissive, or disabled) for selinux operation')
@@ -80,13 +80,10 @@ class selinux::config (
       }
     }
 
-    # setenforce only works when SELinux itself is enabled
-    if $_real_mode in ['enforcing','permissive'] {
-      exec { "change-selinux-status-to-${_real_mode}":
-        command => "setenforce ${sestatus}",
-        unless  => "getenforce | grep -Eqi '${_real_mode}|disabled'",
-        path    => '/bin:/sbin:/usr/bin:/usr/sbin',
-      }
+    exec { "change-selinux-status-to-${_real_mode}":
+      command => "setenforce ${sestatus}",
+      unless  => "getenforce | grep -Eqi '${sestatus}|disabled'",
+      path    => '/bin:/sbin:/usr/bin:/usr/sbin',
     }
   }
 

--- a/spec/classes/selinux_config_mode_spec.rb
+++ b/spec/classes/selinux_config_mode_spec.rb
@@ -41,7 +41,8 @@ describe 'selinux' do
 
           it { is_expected.to contain_file('/var/lib/puppet/puppet-selinux') }
           it { is_expected.to contain_file_line('set-selinux-config-to-enforcing').with(line: 'SELINUX=enforcing') }
-          it { is_expected.to contain_exec('change-selinux-status-to-enforcing').with(command: 'setenforce 1') }
+          it { is_expected.to contain_exec('change-selinux-status-to-enforcing').with(command: 'setenforce enforcing') }
+          it { is_expected.to contain_exec('change-selinux-status-to-enforcing').with(unless: "getenforce | grep -Eqi 'enforcing|disabled'") }
           it { is_expected.not_to contain_file('/.autorelabel') }
         end
 
@@ -50,7 +51,8 @@ describe 'selinux' do
 
           it { is_expected.to contain_file('/var/lib/puppet/puppet-selinux') }
           it { is_expected.to contain_file_line('set-selinux-config-to-permissive').with(line: 'SELINUX=permissive') }
-          it { is_expected.to contain_exec('change-selinux-status-to-permissive').with(command: 'setenforce 0') }
+          it { is_expected.to contain_exec('change-selinux-status-to-permissive').with(command: 'setenforce permissive') }
+          it { is_expected.to contain_exec('change-selinux-status-to-permissive').with(unless: "getenforce | grep -Eqi 'permissive|disabled'") }
           it { is_expected.not_to contain_file('/.autorelabel') }
         end
 


### PR DESCRIPTION
The #245 issue was addressed by #246, but that introduced a new problem:
when mode param is set to 'disabled', runtime mode never gets changed to
'permissive' anymore.

The original problem was different: it was not wrong parameter to
setenforce, instead, the unless command was wrong, always grepping for
'disabled|disabled'.

This change uses literal modes instead of numeric for both exec *and*
unless command and removes conditinal statement added in #246 to restore
original behaviour. It also adds tests for unless param of the exec in
question.

@bjvrielink, could you please test if this works correctly in your environment?

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
