### PR TITLE
Extend enforcing to disabled tests

### DIFF
--- a/spec/acceptance/class_disabled_spec.rb
+++ b/spec/acceptance/class_disabled_spec.rb
@@ -1,26 +1,45 @@
 require 'spec_helper_acceptance'
 
-describe 'selinux class disabled' do
+describe 'selinux class - enforcing to disabled' do
+  before(:all) do
+    shell('sed -i "s/SELINUX=.*/SELINUX=enforcing/" /etc/selinux/config')
+    shell('setenforce Enforcing && test "$(getenforce)" = "Enforcing"')
+  end
+
   let(:pp) do
     <<-EOS
       class { 'selinux': mode => 'disabled' }
     EOS
   end
 
-  it 'runs without errors' do
-    apply_manifest(pp, catch_failures: true)
+  context 'before reboot' do
+    it_behaves_like 'a idempotent resource'
+
+    describe package('selinux-policy-targeted') do
+      it { is_expected.to be_installed }
+    end
+
+    describe file('/etc/selinux/config') do
+      its(:content) { is_expected.to match(%r{^SELINUX=disabled$}) }
+    end
+
+    # Testing for Permissive brecause only after a reboot it's disabled
+    describe command('getenforce') do
+      its(:stdout) { is_expected.to match(%r{^Permissive$}) }
+    end
   end
 
-  describe package('selinux-policy-targeted') do
-    it { is_expected.to be_installed }
-  end
+  context 'after reboot' do
+    before(:all) do
+      hosts.each(&:reboot)
+    end
 
-  describe file('/etc/selinux/config') do
-    its(:content) { is_expected.to match(%r{^SELINUX=disabled$}) }
-  end
+    it 'applies without changes' do
+      apply_manifest(pp, catch_changes: true)
+    end
 
-  # Testing for Permissive brecause only after a reboot it's disabled
-  describe command('getenforce') do
-    its(:stdout) { is_expected.to match(%r{^Permissive$}) }
+    describe command('getenforce') do
+      its(:stdout) { is_expected.to match(%r{^Disabled$}) }
+    end
   end
 end

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -17,8 +17,6 @@ RSpec.configure do |c|
     puppet_module_install(source: proj_root, module_name: 'selinux')
     hosts.each do |host|
       on host, puppet('module', 'install', 'puppetlabs-stdlib'), acceptable_exit_codes: [0, 1]
-      on(host, 'sed -i "s/SELINUX=.*/SELINUX=permissive/" /etc/selinux/config')
-      host.reboot
     end
   end
 end


### PR DESCRIPTION
For better acceptance test coverage for enforcing to disabled. 

The test was successfull now because the SUT was in Permissive mode at the beginning instead of the expected Enforcing mode. If the suite starts with Enforcing the tests fail because it doesn't switch to permissive.

#249 makes the test green again.