### PR TITLE
Add support for installing pre-compiled policy packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,6 @@ This will include the module and manage the SELinux mode (possible values are
 are `targeted`, `minimum`, and `mls`). Note that disabling SELinux requires a reboot
 to fully take effect. It will run in `permissive` mode until then.
 
-
 ### Deploy a custom module using the refpolicy framework
 
 ```puppet
@@ -122,6 +121,19 @@ selinux::module { 'resnet-puppet':
   builder   => 'refpolicy'
 }
 ```
+
+### Using pre-compiled policy packages
+
+```puppet
+selinux::module { 'resnet-puppet':
+  ensure    => 'present',
+  source_pp => 'puppet:///modules/site_puppet/site-puppet.pp',
+}
+```
+
+Note that pre-compiled policy packages may not work reliably
+across all RHEL / CentOS releases. It's up to you as the user
+to test that your packages load properly.
 
 ### Set a boolean value
 

--- a/manifests/module.pp
+++ b/manifests/module.pp
@@ -42,6 +42,7 @@
 #   }
 #
 # @param ensure present or absent
+# @param source_pp the source file (either a puppet URI or local file) of a pre-compiled SELinux policy package. Mutually excludsive with using source files.
 # @param source_te the source file (either a puppet URI or local file) of the SELinux .te file
 # @param source_fc the source file (either a puppet URI or local file) of the SELinux .fc file
 # @param source_if the source file (either a puppet URI or local file) of the SELinux .if file
@@ -51,6 +52,7 @@
 # @param builder either 'simple' or 'refpolicy'. The simple builder attempts to use checkmodule
 #   to build the module, whereas 'refpolicy' uses the refpolicy framework, but requires 'make'
 define selinux::module(
+  Optional[String] $source_pp = undef,
   Optional[String] $source_te = undef,
   Optional[String] $source_fc = undef,
   Optional[String] $source_if = undef,
@@ -76,13 +78,21 @@ define selinux::module(
   $build_command = pick($builder, $::selinux::default_builder, 'none') ? {
       'simple'    => shellquote("${::selinux::module_build_root}/bin/selinux_build_module_simple.sh", $title, $module_dir),
       'refpolicy' => shellquote('make', '-f', $::selinux::refpolicy_makefile, "${title}.pp"),
-      'none'      => fail('No builder or default builder specified')
+      'none'      => undef
   }
 
   Anchor['selinux::module pre']
   -> Selinux::Module[$title]
   -> Anchor['selinux::module post']
+
   $has_source = (pick($source_te, $source_fc, $source_if, $content_te, $content_fc, $content_if, false) != false)
+  if $has_source and $build_command == undef {
+    fail('No builder or default builder specified')
+  }
+
+  if $has_source and $source_pp != undef {
+    fail('Specifying source files and a pre-compiled policy package are mutually exclusive options')
+  }
 
   if $has_source and $ensure == 'present' {
     file {"${module_file}.te":
@@ -125,6 +135,29 @@ define selinux::module(
       creates => "${module_file}.pp",
       notify  => Exec["install-module-${title}"],
     }
+    $install = true
+  } elsif $source_pp != undef and $ensure == 'present' {
+    file {"${module_file}.pp":
+      ensure => 'file',
+      source => $source_pp,
+      notify => Exec["clean-module-${title}"],
+    }
+
+    exec { "clean-module-${title}":
+      path        => '/bin:/usr/bin',
+      cwd         => $module_dir,
+      command     => "rm -f '${module_file}.loaded'",
+      refreshonly => true,
+      notify      => Exec["install-module-${title}"],
+    }
+
+    $install = true
+  } else {
+    # no source and no .pp, just do plain selmodule {$title:}
+    $install = false
+  }
+
+  if $install {
     # we need to install the module manually because selmodule is kind of dumb. It ends up
     # working fine, though.
     exec { "install-module-${title}":
@@ -138,7 +171,8 @@ define selinux::module(
     # ensure it doesn't get purged if it exists
     file { "${module_file}.loaded": }
   }
-  $module_path = $has_source ? {
+
+  $module_path = ($has_source or $source_pp != undef) ? {
     true  => "${module_file}.pp",
     false => undef
   }

--- a/spec/defines/selinux_module_spec.rb
+++ b/spec/defines/selinux_module_spec.rb
@@ -151,6 +151,35 @@ describe 'selinux::module' do
           is_expected.to raise_error(Puppet::Error, %r{simple builder does not support})
         end
       end
+
+      context 'present case with pre-compiled policy package' do
+        let(:params) do
+          {
+            source_pp: 'puppet:///modules/mymodule/selinux/mymodule.pp'
+          }
+        end
+
+        it { is_expected.to contain_file(workdir) }
+        it { is_expected.to contain_file("#{workdir}/mymodule.pp").that_notifies('Exec[clean-module-mymodule]') }
+        it { is_expected.to contain_exec('clean-module-mymodule').with(command: "rm -f '#{module_basepath}.loaded'", cwd: workdir) }
+        it { is_expected.to contain_exec('install-module-mymodule').with(command: "semodule -i #{module_basepath}.pp && touch #{module_basepath}.loaded", cwd: workdir, creates: "#{module_basepath}.loaded") }
+        it { is_expected.to contain_selmodule('mymodule').with_ensure('present', selmodulepath: workdir) }
+      end
+
+      context 'conflicting parameters' do
+        let(:params) do
+          {
+            source_pp: 'puppet:///modules/mymodule/selinux/mymodule.pp',
+            source_te: 'puppet:///modules/mymodule/selinux/mymodule.te',
+            builder: 'simple'
+          }
+        end
+
+        it do
+          is_expected.to raise_error(Puppet::Error, %r{mutually exclusive})
+        end
+      end
+
       context 'absent case' do
         let(:params) do
           {


### PR DESCRIPTION
This PR adds support for specifying a source for a precompiled policy package in the `selinux::module` defined type.

Currently mostly untested, but I'm submitting this here for review anyway. I intend to test it later today or tomorrow if I don't have time today.
