### PR TITLE
Switch to "facts" hash for SELinux facts

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -39,7 +39,7 @@ class selinux::config (
     fail("Use of private class ${name} by ${caller_module_name}")
   }
 
-  if ($mode == 'enforcing' and !$::selinux) {
+  if ($mode == 'enforcing' and !$facts['selinux']) {
     notice('SELinux is disabled. Forcing configuration to permissive to avoid problems. To disable this warning, explicitly set selinux::mode to permissive or disabled.')
     $_real_mode = 'permissive'
   } else {
@@ -56,7 +56,7 @@ class selinux::config (
     case $_real_mode {
       'permissive', 'disabled': {
         $sestatus = 'permissive'
-        if $_real_mode == 'disabled' and defined('$::selinux_current_mode') and $::selinux_current_mode == 'permissive' {
+        if $_real_mode == 'disabled' and $facts['selinux_current_mode'] == 'permissive' {
           notice('A reboot is required to fully disable SELinux. SELinux will operate in Permissive mode until a reboot')
         }
       }
@@ -71,7 +71,7 @@ class selinux::config (
     # a complete relabeling is required when switching from disabled to
     # permissive or enforcing. Ensure the autorelabel trigger file is created.
     if $_real_mode in ['enforcing','permissive'] and
-      !$::selinux {
+      !$facts['selinux'] {
       file { '/.autorelabel':
         ensure  => 'file',
         owner   => 'root',


### PR DESCRIPTION
#### Pull Request (PR) description
The calls to the global `$::selinux` facts were confusing given the name
of the module.

Modified all calls to `$::selinux` facts to use the `$facts` hash as
appropriate.

#### This Pull Request (PR) fixes the following issues

Fixes #258
