### PR TITLE
Change - Update module parameters to support older Fedora releases

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -5,21 +5,31 @@
 class selinux::params {
   $module_build_root = "${facts['puppet_vardir']}/puppet-selinux"
 
-  case $facts['os']['family'] {
-    'RedHat': {
-      if $facts['os']['name'] == 'Amazon' {
-        $package_name = 'policycoreutils'
-      } else {
-        $package_name = $facts['os']['release']['major'] ? {
-          '5'     => 'policycoreutils',
-          '6'     => 'policycoreutils-python',
-          '7'     => 'policycoreutils-python',
-          default => 'policycoreutils-python-utils',
-        }
+  case $facts['os']['name'] {
+    'Amazon': {
+      $package_name = 'policycoreutils'
+    }
+
+    'CentOS', 'RedHat': {
+      $package_name = $facts['os']['release']['major'] ? {
+        '5'     => 'policycoreutils',
+        '6'     => 'policycoreutils-python',
+        '7'     => 'policycoreutils-python',
+        default => 'policycoreutils-python-utils',
       }
     }
+
+    'Fedora': {
+      $sx_fs_mount = '/sys/fs/selinux'
+      $package_name = $facts['os']['release']['major'] ? {
+        /19|20/  => 'policycoreutils-python',
+        /2[1-3]/ => 'policycoreutils-devel',
+        default  => 'policycoreutils-python-utils',
+      }
+    }
+
     default: {
-      fail("${facts['os']['family']} is not supported")
+      fail("${facts['os']['name']} is not supported by ${name}")
     }
   }
 }


### PR DESCRIPTION
Recent changes to the manifest/params.pp file have caused breakage
on servers running older Fedora release.  Update manifest to avoid
this in environments that still need support for legacy hosts.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
This commit fixes support for clients running Fedora 20-23.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
