### PR TITLE
Update supported OS list in module metadata

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -12,21 +12,24 @@
       "operatingsystem": "RedHat",
       "operatingsystemrelease": [
         "6",
-        "7"
+        "7",
+        "8"
       ]
     },
     {
       "operatingsystem": "CentOS",
       "operatingsystemrelease": [
         "6",
-        "7"
+        "7",
+        "8"
       ]
     },
     {
       "operatingsystem": "Fedora",
       "operatingsystemrelease": [
         "28",
-        "29"
+        "29",
+        "30"
       ]
     }
   ],


### PR DESCRIPTION
Added RedHat 8 and Fedora 30 to the supported OS list.