### PR TITLE
Avoid puppet errors when SELinux is disabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,9 +67,6 @@ running system.
   does) the order is important. If you add /my/folder before /my/folder/subfolder
   only /my/folder will match (limitation of SELinux). There is no such limitation
   to file-contexts defined in SELinux modules. (GH-121)
-* While SELinux is disabled the defined types `selinux::boolean`,
-  `selinux::fcontext`, `selinux::port` will produce puppet agent runtime errors
-  because the used tools fail.
 * If you try to remove a built-in permissive type, the operation will appear to succeed
   but will actually have no effect, making your puppet runs non-idempotent.
 * The `selinux_port` provider may misbehave if the title does not correspond to

--- a/manifests/boolean.pp
+++ b/manifests/boolean.pp
@@ -36,8 +36,11 @@ define selinux::boolean (
     default              => undef,
   }
 
-  selboolean { $name:
-    value      => $value,
-    persistent => $persistent,
+  # Do nothing unless SELinux is enabled
+  if $facts['selinux'] {
+    selboolean { $name:
+      value      => $value,
+      persistent => $persistent,
+    }
   }
 }

--- a/manifests/fcontext.pp
+++ b/manifests/fcontext.pp
@@ -54,12 +54,15 @@ define selinux::fcontext(
     fail('"filetype" must be one of: a,f,d,c,b,s,l,p - see "man semanage-fcontext"')
   }
 
-  # make sure the title is correct or the provider will misbehave
-  selinux_fcontext {"${pathspec}_${filetype}":
-    ensure    => $ensure,
-    pathspec  => $pathspec,
-    seltype   => $seltype,
-    file_type => $filetype,
-    seluser   => $seluser,
+  # Do nothing unless SELinux is enabled
+  if $facts['selinux'] {
+    # make sure the title is correct or the provider will misbehave
+    selinux_fcontext {"${pathspec}_${filetype}":
+      ensure    => $ensure,
+      pathspec  => $pathspec,
+      seltype   => $seltype,
+      file_type => $filetype,
+      seluser   => $seluser,
+    }
   }
 }

--- a/manifests/port.pp
+++ b/manifests/port.pp
@@ -56,11 +56,14 @@ define selinux::port (
     fail("Malformed port range: ${port_range}")
   }
 
-  selinux_port {"${protocol}_${range[0]}-${range[1]}":
-    ensure    => $ensure,
-    low_port  => $range[0],
-    high_port => $range[1],
-    seltype   => $seltype,
-    protocol  => $protocol,
+  # Do nothing unless SELinux is enabled
+  if $facts['selinux'] {
+    selinux_port {"${protocol}_${range[0]}-${range[1]}":
+      ensure    => $ensure,
+      low_port  => $range[0],
+      high_port => $range[1],
+      seltype   => $seltype,
+      protocol  => $protocol,
+    }
   }
 }

--- a/spec/defines/selinux_boolean_spec.rb
+++ b/spec/defines/selinux_boolean_spec.rb
@@ -12,36 +12,76 @@ describe 'selinux::boolean' do
       it { is_expected.to contain_selinux__boolean('mybool').that_requires('Anchor[selinux::module post]') }
       it { is_expected.to contain_selinux__boolean('mybool').that_comes_before('Anchor[selinux::end]') }
 
-      ['on', true, 'present'].each do |value|
-        context value do
-          let(:params) do
-            {
-              ensure: value
-            }
-          end
+      context 'SELinux enabled' do
+        let(:facts) do
+          facts.merge(selinux: true)
+        end
 
-          it do
-            is_expected.to contain_selboolean('mybool').with(
-              'value'      => 'on',
-              'persistent' => true
-            )
+        ['on', true, 'present'].each do |value|
+          context value do
+            let(:params) do
+              {
+                ensure: value
+              }
+            end
+
+            it do
+              is_expected.to contain_selboolean('mybool').with(
+                'value'      => 'on',
+                'persistent' => true
+              )
+            end
+          end
+        end
+
+        ['off', false, 'absent'].each do |value|
+          context value do
+            let(:params) do
+              {
+                ensure: value
+              }
+            end
+
+            it do
+              is_expected.to contain_selboolean('mybool').with(
+                'value'      => 'off',
+                'persistent' => true
+              )
+            end
           end
         end
       end
 
-      ['off', false, 'absent'].each do |value|
-        context value do
-          let(:params) do
-            {
-              ensure: value
-            }
-          end
+      context 'SELinux disabled' do
+        let(:facts) do
+          facts.merge(selinux: false)
+        end
 
-          it do
-            is_expected.to contain_selboolean('mybool').with(
-              'value'      => 'off',
-              'persistent' => true
-            )
+        ['on', true, 'present'].each do |value|
+          context value do
+            let(:params) do
+              {
+                ensure: value
+              }
+            end
+
+            it do
+              is_expected.not_to contain_selboolean('mybool')
+            end
+          end
+        end
+
+        ['off', false, 'absent'].each do |value|
+          context value do
+            let(:params) do
+              {
+                ensure: value
+              }
+            end
+
+            it do
+              is_expected.not_to contain_selboolean('mybool')
+            end
           end
         end
       end

--- a/spec/defines/selinux_fcontext_spec.rb
+++ b/spec/defines/selinux_fcontext_spec.rb
@@ -6,7 +6,7 @@ describe 'selinux::fcontext' do
   on_supported_os.each do |os, facts|
     context "on #{os}" do
       let(:facts) do
-        facts
+        facts.merge(selinux: true)
       end
 
       context 'ordering' do

--- a/spec/defines/selinux_port_spec.rb
+++ b/spec/defines/selinux_port_spec.rb
@@ -6,7 +6,7 @@ describe 'selinux::port' do
   on_supported_os.each do |os, facts|
     context "on #{os}" do
       let(:facts) do
-        facts
+        facts.merge(selinux: true)
       end
 
       context 'ordering' do


### PR DESCRIPTION
Fixes #286.  Puppet will no longer display a runtime error when applying a manifest on a node with selinux disabled.  These changes essentially make the `selinux::boolean`, `selinux::fcontext`, and `selinux::port` types do nothing when SELinux is disabled.