### PR TITLE
Use legacy facts in the params class

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -5,12 +5,12 @@
 class selinux::params {
   $module_build_root = "${facts['puppet_vardir']}/puppet-selinux"
 
-  case $facts['os']['family'] {
+  case $facts['osfamily'] {
     'RedHat': {
-      if $facts['os']['name'] == 'Amazon' {
+      if $facts['operatingsystem'] == 'Amazon' {
         $package_name = 'policycoreutils'
       } else {
-        $package_name = $facts['os']['release']['major'] ? {
+        $package_name = $facts['operatingsystemmajrelease'] ? {
           '5'     => 'policycoreutils',
           '6'     => 'policycoreutils-python',
           '7'     => 'policycoreutils-python',
@@ -19,7 +19,7 @@ class selinux::params {
       }
     }
     default: {
-      fail("${facts['os']['family']} is not supported")
+      fail("${facts['osfamily']} is not supported")
     }
   }
 }


### PR DESCRIPTION
Recent changes to the params class cause puppet runs to fail on
older clients that do not have an "os" fact defined.  Unit tests
in Travis-CI are also failing when other modules attempt to use
this module as a dependecy.  For example, see the following URL:

https://travis-ci.org/puppetlabs/puppetlabs-postgresql/jobs/567084563
