### PR TITLE
Fix selinux_port on RHEL 8/CentOS 8

### DIFF
--- a/lib/facter/selinux_python_command.rb
+++ b/lib/facter/selinux_python_command.rb
@@ -1,0 +1,15 @@
+Facter.add(:selinux_python_command) do
+  confine osfamily: 'RedHat'
+  setcode do
+    if File.exist? '/usr/libexec/platform-python'
+      # RHEL 8 / CentOS 8
+      '/usr/libexec/platform-python'
+    elsif Facter::Core::Execution.execute('rpm -q python3-libsemanage') !~ %r{not installed}
+      'python3'
+    else
+      # This might be python 2 or 3. Keeping it at 'python' matches the module
+      # worked previously
+      'python'
+    end
+  end
+end

--- a/lib/facter/selinux_semanage_is_python3.rb
+++ b/lib/facter/selinux_semanage_is_python3.rb
@@ -1,6 +1,0 @@
-Facter.add(:selinux_semanage_is_python3) do
-  confine osfamily: 'RedHat'
-  setcode do
-    Facter::Core::Execution.execute('rpm -q python3-libsemanage') !~ %r{not installed}
-  end
-end

--- a/lib/puppet/provider/selinux_port/semanage.rb
+++ b/lib/puppet/provider/selinux_port/semanage.rb
@@ -5,8 +5,7 @@ Puppet::Type.type(:selinux_port).provide(:semanage) do
   # SELinux must be enabled. Is there a way to get a better error message?
   confine selinux: true
 
-  # custom fact, needed for fedora 24+
-  python_command = Facter.value(:selinux_semanage_is_python3) ? 'python3' : 'python'
+  python_command = Facter.value(:selinux_python_command)
   # current file path is lib/puppet/provider/selinux_port/semanage.rb
   # semanage_ports.py is lib/puppet_x/voxpupuli/selinux/semanage_ports.py
   PORTS_HELPER = File.expand_path('../../../../puppet_x/voxpupuli/selinux/semanage_ports.py', __FILE__)


### PR DESCRIPTION
Hi,

this PR makes the selinux_port helper use the platform Python interpreter if it exists. This makes it work on on RHEL 8 / CentOS 8.

The platform python interpreter is guaranteed to exist, as several RHEL components depend on it.

This has seen very light testing, but at least it didn't break my test system.