### PR TITLE
Amazon Linux v2 should use the new fcontext filetype format

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,6 +30,9 @@ group :test do
   gem 'coveralls',                                                  :require => false
   gem 'simplecov-console',                                          :require => false
   gem 'parallel_tests',                                             :require => false
+  # we require unreleased Fedora 30 fact sets
+  # https://github.com/camptocamp/facterdb/commit/1bc038fd42aac53344ac1ee9c129cbccf5b5c0aa
+  gem 'facterdb',                                                   :require => false, :git => 'https://github.com/camptocamp/facterdb.git', :branch => 'master'
 end
 
 group :development do

--- a/lib/puppet/provider/selinux_fcontext/semanage.rb
+++ b/lib/puppet/provider/selinux_fcontext/semanage.rb
@@ -9,10 +9,11 @@ Puppet::Type.type(:selinux_fcontext).provide(:semanage) do
 
   mk_resource_methods
 
-  osfamily  = Facter.value('osfamily')
-  osversion = Facter.value('operatingsystemmajrelease')
+  osfamily        = Facter.value('osfamily')
+  osversion       = Facter.value('operatingsystemmajrelease')
+  operatingsystem = Facter.value('operatingsystem')
   @old_semanage = false
-  if (osfamily == 'RedHat') && (Puppet::Util::Package.versioncmp(osversion, '6') <= 0)
+  if (osfamily == 'RedHat') && (Puppet::Util::Package.versioncmp(osversion, '6') <= 0) && (operatingsystem != 'Amazon')
     @old_semanage = true
   end
 

--- a/metadata.json
+++ b/metadata.json
@@ -37,6 +37,12 @@
       "operatingsystemrelease": [
         "10"
       ]
+    },
+    {
+      "operatingsystem": "Amazon",
+      "operatingsystemrelease": [
+        "2"
+      ]
     }
   ],
   "dependencies": [


### PR DESCRIPTION
#### Pull Request (PR) description

Amazon Linux v2 is part of the RedHat family, but they started to use their own versioning. Because of that, the originally introduces check for older RHEL distributions thinks Amazon Linux v2 is an older version (`operatingsystemmajrelease == 2`) and tries to use `all files` instead of `a` which is not working.

#### This Pull Request (PR) fixes the following issues
n/a
