### PR TITLE
examples/enable_and_targeted.pp: match type to filename

### DIFF
--- a/examples/enable_and_targeted.pp
+++ b/examples/enable_and_targeted.pp
@@ -13,5 +13,5 @@
 
 class { 'selinux':
   mode => 'enforcing',
-  type => 'mls',
+  type => 'targeted',
 }


### PR DESCRIPTION
Filename says "targeted", so type should also be "targeted". I guess "mls" was a copy-paste error.