### PR TITLE
Deprecate selinux_python_command fact and move handling into provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ running system.
 
 ## Known problems / limitations
 
+* The `selinux_python_command` fact is now deprecated and will be removed in
+  version 4 of the module.
 * If SELinux is disabled and you want to switch to permissive or enforcing you
   are required to reboot the system (limitation of SELinux). The module won't
   do this for you.

--- a/lib/facter/selinux_python_command.rb
+++ b/lib/facter/selinux_python_command.rb
@@ -1,3 +1,4 @@
+# DEPRECATED: Determine the path to python on the system
 Facter.add(:selinux_python_command) do
   confine osfamily: 'RedHat'
   setcode do

--- a/lib/puppet_x/voxpupuli/selinux/semanage_ports.py
+++ b/lib/puppet_x/voxpupuli/selinux/semanage_ports.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python
 # This script uses libsemanage directly to access the ports list
 # it is *much* faster than semanage port -l
 

--- a/metadata.json
+++ b/metadata.json
@@ -54,7 +54,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 5.5.8 < 7.0.0"
+      "version_requirement": ">= 5.5.8 < 8.0.0"
     }
   ]
 }

--- a/metadata.json
+++ b/metadata.json
@@ -29,7 +29,8 @@
       "operatingsystemrelease": [
         "30",
         "31",
-        "32"
+        "32",
+        "33"
       ]
     },
     {

--- a/test-acceptance-with-vagrant
+++ b/test-acceptance-with-vagrant
@@ -9,9 +9,10 @@ export PUPPET_INSTALL_TYPE=agent
 
 # https://github.com/puppetlabs/beaker-hostgenerator/pull/184 fixes the Fedora boxes and adds 32
 for layout in \
-  {debian10,centos{6,7}}'-64a' \
-  'fedora30-64a{box=fedora/30-cloud-base}' \
-  'fedora31-64a{box=fedora/31-cloud-base}'
+  {debian10,centos{7,8}}'-64a' \
+  'fedora31-64a{box=fedora/31-cloud-base}' \
+  'fedora32-64a{box=fedora/32-cloud-base}' \
+  'fedora33-64a{box=fedora/33-cloud-base}'
 do
-	BEAKER_setfile="$layout" bundle exec rake beaker
+  BEAKER_setfile="$layout" bundle exec rake beaker
 done


### PR DESCRIPTION
#### Pull Request (PR) description

Fixed:
  * Moved the python discovery into the semanage_ports provider
  * Ensure that the correct python is chosen by attempting to load the
    `semanage` library
  * Removed the #! line from the semanage_ports.py file to fix RPM
    building
  * Removed CentOS 6 support from `test-acceptance-with-vagrant` since
    it will no longer function due to upstream deprecation

Changed:
  * Marked the `selinux_python_command` fact as deprecated in the README
    since the logic now resides in the provider itself
  * Added support for Puppet 7
  * Added Fedora 33 support

#### This Pull Request (PR) fixes the following issues

Fixes #335
Fixes #342 
Fixed #343 