### PR TITLE
Simplify loading of selinux sandbox tooling

### DIFF
--- a/data/os/Debian.yaml
+++ b/data/os/Debian.yaml
@@ -1,3 +1,6 @@
 ---
 selinux::manage_auditd_package: true
 selinux::manage_setroubleshoot_packages: false
+selinux::manage_selinux_sandbox_packages: false
+selinux::selinux_sandbox_package_names:
+ - policycoreutils-sandbox

--- a/data/os/RedHat.yaml
+++ b/data/os/RedHat.yaml
@@ -5,3 +5,7 @@ selinux::manage_setroubleshoot_packages: false
 selinux::setroubleshoot_package_names:
   - setroubleshoot
   - setroubleshoot-plugins
+selinux::manage_selinux_sandbox_packages: false
+selinux::selinux_sandbox_package_names: 
+ - policycoreutils-sandbox
+ - selinux-policy-sandbox

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -21,6 +21,8 @@
 # @param auditd_package_name used when `manage_auditd_package` is true
 # @param manage_setroubleshoot_packages manage the setroubleshoot packages
 # @param setroubleshoot_package_names the names of the setroubleshoot packages
+# @param manage_selinux_sandbox_packages manage the selinux sandbox packages
+# @param selinux_sandbox_package_names the names of the selinux sandbox packages
 # @param module_build_root directory where modules are built. Defaults to `$vardir/puppet-selinux`
 # @param default_builder which builder to use by default with selinux::module
 # @param boolean Hash of selinux::boolean resource parameters
@@ -36,6 +38,8 @@ class selinux (
   String $refpolicy_package_name,
   Boolean $manage_setroubleshoot_packages,
   Array[String] $setroubleshoot_package_names                 = [],
+  Boolean $manage_selinux_sandbox_packages,
+  Array[String] $selinux_sandbox_package_names                = [],
   Optional[Enum['enforcing', 'permissive', 'disabled']] $mode = undef,
   Optional[Enum['targeted', 'minimum', 'mls']] $type          = undef,
   Stdlib::Absolutepath $refpolicy_makefile                    = '/usr/share/selinux/devel/Makefile',
@@ -52,12 +56,14 @@ class selinux (
   Optional[Hash] $exec_restorecon = undef,
 ) {
   class { 'selinux::package':
-    manage_package                 => $manage_package,
-    package_names                  => Array.new($package_name, true),
-    manage_auditd_package          => $manage_auditd_package,
-    auditd_package_name            => $auditd_package_name,
-    manage_setroubleshoot_packages => $manage_setroubleshoot_packages,
-    setroubleshoot_package_names   => $setroubleshoot_package_names,
+    manage_package                  => $manage_package,
+    package_names                   => Array.new($package_name, true),
+    manage_auditd_package           => $manage_auditd_package,
+    auditd_package_name             => $auditd_package_name,
+    manage_setroubleshoot_packages  => $manage_setroubleshoot_packages,
+    setroubleshoot_package_names    => $setroubleshoot_package_names,
+    manage_selinux_sandbox_packages => $manage_selinux_sandbox_packages,
+    selinux_sandbox_package_names   => $selinux_sandbox_package_names,
   }
 
   class { 'selinux::config':

--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -6,6 +6,10 @@
 # @param package_names See main class
 # @param manage_auditd_package See main class
 # @param auditd_package_name See main class
+# @param manage_setroubleshoot_packages See main class
+# @param setroubleshoot_package_names See main class
+# @param manage_selinux_sandbox_packages See main class
+# @param selinux_sandbox_package_names See main class
 #
 class selinux::package (
   Boolean $manage_package,
@@ -14,6 +18,8 @@ class selinux::package (
   String[1] $auditd_package_name,
   Boolean $manage_setroubleshoot_packages,
   Array[String] $setroubleshoot_package_names,
+  Boolean $manage_selinux_sandbox_packages,
+  Array[String] $selinux_sandbox_package_names,
 ) {
   assert_private()
   if $manage_package {
@@ -24,5 +30,8 @@ class selinux::package (
   }
   if $manage_setroubleshoot_packages {
     ensure_packages ($setroubleshoot_package_names)
+  }
+  if $manage_selinux_sandbox_packages {
+    ensure_packages ($selinux_sandbox_package_names)
   }
 }

--- a/spec/classes/selinux_package_spec.rb
+++ b/spec/classes/selinux_package_spec.rb
@@ -133,5 +133,24 @@ describe 'selinux' do
       it { is_expected.to contain_package('setroubleshoot').with(ensure: 'installed') }
       it { is_expected.to contain_package('setroubleshoot-plugins').with(ensure: 'installed') }
     end
+
+    context 'install selinux sandbox packages' do
+      let(:facts) do
+        {
+          osfamily: 'RedHat',
+          operatingsystem: 'RedHat',
+          operatingsystemmajrelease: '7',
+          os: { release: { major: 7 }, name: 'RedHat', family: 'RedHat' }
+        }
+      end
+      let(:params) do
+        {
+          manage_selinux_sandbox_packages: true
+        }
+      end
+
+      it { is_expected.to contain_package('policycoreutils-sandbox').with(ensure: 'installed') }
+      it { is_expected.to contain_package('selinux-policy-sandbox').with(ensure: 'installed') }
+    end
   end
 end


### PR DESCRIPTION
#### Pull Request (PR) description
Add a simple boolean to also load the supplemental selinux-sandbox tooling.  This tooling can help users restrict their own processes without the need to load custom policy.

#### This Pull Request (PR) fixes the following issues
None
