### PR TITLE
add missing dep on puppetlabs/selinux_core

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -50,6 +50,10 @@
     {
       "name": "puppetlabs/stdlib",
       "version_requirement": ">= 4.18.0 < 9.0.0"
+    },
+    {
+      "name": "puppetlabs/selinux_core",
+      "version_requirement": ">= 1.2.0 < 2.0.0"
     }
   ],
   "requirements": [


### PR DESCRIPTION
This module is using the `selmodule` resource type provided by
puppetlabs/selinux_core.