### PR TITLE
Add Debian 11 support by moving the policy packages definition

### DIFF
--- a/data/os/Debian.yaml
+++ b/data/os/Debian.yaml
@@ -1,4 +1,9 @@
 ---
+selinux::package_name:
+  - policycoreutils-python-utils
+  - selinux-basics
+  - selinux-policy-default
+selinux::refpolicy_package_name: selinux-policy-dev
 selinux::manage_auditd_package: true
 selinux::manage_setroubleshoot_packages: false
 selinux::manage_selinux_sandbox_packages: false

--- a/data/os/Debian/Debian/10.yaml
+++ b/data/os/Debian/Debian/10.yaml
@@ -1,6 +1,0 @@
----
-selinux::package_name:
-  - policycoreutils-python-utils
-  - selinux-basics
-  - selinux-policy-default
-selinux::refpolicy_package_name: selinux-policy-dev

--- a/metadata.json
+++ b/metadata.json
@@ -36,7 +36,8 @@
     {
       "operatingsystem": "Debian",
       "operatingsystemrelease": [
-        "10"
+        "10",
+        "11"
       ]
     },
     {


### PR DESCRIPTION

#### Pull Request (PR) description
Provide default package names for Debian based systems.  Can still override for specific versions if need be.

#### This Pull Request (PR) fixes the following issues
One of my internal modules tests against Debian 11.  I didn't guard the selinux bits and noticed the package names don't have a default set for Debian.