### PR TITLE
Add Debian 11 support

### DIFF
--- a/data/os/Debian.yaml
+++ b/data/os/Debian.yaml
@@ -2,5 +2,10 @@
 selinux::manage_auditd_package: true
 selinux::manage_setroubleshoot_packages: false
 selinux::manage_selinux_sandbox_packages: false
+selinux::package_name:
+  - policycoreutils-python-utils
+  - selinux-basics
+  - selinux-policy-default
+selinux::refpolicy_package_name: selinux-policy-dev
 selinux::selinux_sandbox_package_names:
  - policycoreutils-sandbox

--- a/data/os/Debian/Debian/10.yaml
+++ b/data/os/Debian/Debian/10.yaml
@@ -1,6 +1,0 @@
----
-selinux::package_name:
-  - policycoreutils-python-utils
-  - selinux-basics
-  - selinux-policy-default
-selinux::refpolicy_package_name: selinux-policy-dev

--- a/metadata.json
+++ b/metadata.json
@@ -36,7 +36,8 @@
     {
       "operatingsystem": "Debian",
       "operatingsystemrelease": [
-        "10"
+        "10",
+        "11"
       ]
     },
     {

--- a/metadata.json
+++ b/metadata.json
@@ -55,7 +55,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 5.5.8 < 8.0.0"
+      "version_requirement": ">= 6.1.0 < 8.0.0"
     }
   ]
 }


### PR DESCRIPTION
This copies the Debian 10 data to the base version, which makes it also apply to other Debian versions.

Includes https://github.com/voxpupuli/puppet-selinux/pull/361 to fix CI.