### PR TITLE
selinux::login: Miscellaneous fixes

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -913,6 +913,12 @@ The name of the linux user or group to map.
 
 The selinux user to map to.
 
+##### `source`
+
+Valid values: `policy`, `local`
+
+Source of the login configuration - either policy or local
+
 #### Parameters
 
 The following parameters are available in the `selinux_login` type.

--- a/lib/puppet/provider/selinux_login/semanage.rb
+++ b/lib/puppet/provider/selinux_login/semanage.rb
@@ -85,13 +85,13 @@ Puppet::Type.type(:selinux_login).provide(:semanage) do
   end
 
   def self.prefetch(resources)
-    # is there a better way to do this? map port/protocol pairs to the provider regardless of the title
+    # is there a better way to do this? Map selinux_user/selinux_login_name to the provider regardless of the title
     # and make sure all system resources have ensure => :present so that we don't try to remove them
     instances.each do |provider|
       resource = resources[provider.name]
       if resource
         unless resource[:selinux_user].to_s == provider.selinux_user && resource[:selinux_login_name].to_s == provider.selinux_login_name || resource.purging?
-          raise Puppet::ResourceError, "Selinux_port['#{resource[:name]}']: title does not match its port and protocol, and a conflicting resource exists"
+          raise Puppet::ResourceError, "Selinux_login['#{resource[:name]}']: title does not match its seuser and login, and a conflicting resource exists"
         end
 
         resource.provider = provider

--- a/lib/puppet/provider/selinux_login/semanage.rb
+++ b/lib/puppet/provider/selinux_login/semanage.rb
@@ -102,8 +102,8 @@ Puppet::Type.type(:selinux_login).provide(:semanage) do
     instances.each do |provider|
       resource = resources[provider.name]
       if resource
-        unless resource[:selinux_user].to_s == provider.selinux_user && resource[:selinux_login_name].to_s == provider.selinux_login_name || resource.purging?
-          raise Puppet::ResourceError, "Selinux_login['#{resource[:name]}']: title does not match its seuser and login ('#{provider.name}' != '#{provider.selinux_user}_#{provider.selinux_login_name}'), and a conflicting resource exists"
+        unless resource[:selinux_login_name].to_s == provider.selinux_login_name || resource.purging?
+          raise Puppet::ResourceError, "Selinux_login['#{resource[:name]}']: title does not match its login ('#{provider.name}' != '#{provider.selinux_login_name}'), and a conflicting resource exists"
         end
 
         resource.provider = provider
@@ -112,7 +112,7 @@ Puppet::Type.type(:selinux_login).provide(:semanage) do
         resources.each_values do |res|
           next unless res[:selinux_user] == provider.selinux_user && res[:selinux_login_name] == provider.selinux_login_name
 
-          warning("Selinux_login['#{res[:name]}']: title does not match its seuser and login ('#{provider.name}' != '#{provider.selinux_user}_#{provider.selinux_login_name}')")
+          warning("Selinux_login['#{res[:name]}']: title does not match its login ('#{provider.name}' != '#{provider.selinux_login_name}')")
           resource.provider = provider
           resource[:ensure] = :present if provider.source == :policy
         end

--- a/lib/puppet/provider/selinux_login/semanage.rb
+++ b/lib/puppet/provider/selinux_login/semanage.rb
@@ -78,6 +78,7 @@ Puppet::Type.type(:selinux_login).provide(:semanage) do
 
       ret[key] = {
         ensure: :present,
+        title: key,
         name: key,
         source: source,
         selinux_login_name: selinux_login_name,

--- a/lib/puppet/provider/selinux_login/semanage.rb
+++ b/lib/puppet/provider/selinux_login/semanage.rb
@@ -100,7 +100,7 @@ Puppet::Type.type(:selinux_login).provide(:semanage) do
         resources.each_value do |res|
           next unless res[:selinux_user] == provider.selinux_user && res[:selinux_login_name] == provider.selinux_login_name
 
-          warning("Selinux_login['#{resource[:name]}']: title does not match format selinux_login_name_selinux_user")
+          warning("Selinux_login['#{res[:name]}']: title does not match format selinux_login_name_selinux_user")
           resource.provider = provider
           resource[:ensure] = :present if provider.source == :policy
         end

--- a/lib/puppet/provider/selinux_login/semanage.rb
+++ b/lib/puppet/provider/selinux_login/semanage.rb
@@ -102,16 +102,16 @@ Puppet::Type.type(:selinux_login).provide(:semanage) do
       resource = resources[provider.name]
       if resource
         unless resource[:selinux_user].to_s == provider.selinux_user && resource[:selinux_login_name].to_s == provider.selinux_login_name || resource.purging?
-          raise Puppet::ResourceError, "Selinux_login['#{resource[:name]}']: title does not match its seuser and login, and a conflicting resource exists"
+          raise Puppet::ResourceError, "Selinux_login['#{resource[:name]}']: title does not match its seuser and login ('#{provider.name}' != '#{provider.selinux_user}_#{provider.selinux_login_name}'), and a conflicting resource exists"
         end
 
         resource.provider = provider
         resource[:ensure] = :present if provider.source == :policy
       else
-        resources.each_value do |res|
+        resources.each_values do |res|
           next unless res[:selinux_user] == provider.selinux_user && res[:selinux_login_name] == provider.selinux_login_name
 
-          warning("Selinux_login['#{res[:name]}']: title does not match format selinux_login_name_selinux_user")
+          warning("Selinux_login['#{res[:name]}']: title does not match its seuser and login ('#{provider.name}' != '#{provider.selinux_user}_#{provider.selinux_login_name}')")
           resource.provider = provider
           resource[:ensure] = :present if provider.source == :policy
         end

--- a/lib/puppet/provider/selinux_login/semanage.rb
+++ b/lib/puppet/provider/selinux_login/semanage.rb
@@ -125,6 +125,11 @@ Puppet::Type.type(:selinux_login).provide(:semanage) do
     semanage(*args)
   end
 
+  def sync
+    args = ['login', '-m', '-s', @resource[:selinux_user], @resource[:selinux_login_name]]
+    semanage(*args)
+  end
+
   def destroy
     args = ['login', '-d', @property_hash[:selinux_login_name]]
     semanage(*args)

--- a/lib/puppet/type/selinux_login.rb
+++ b/lib/puppet/type/selinux_login.rb
@@ -17,6 +17,12 @@ Puppet::Type.newtype(:selinux_login) do
   newproperty(:selinux_user) do
     desc 'The selinux user to map to.'
     isrequired
+
+    def sync
+      event = super
+      provider.sync
+      event
+    end
   end
 
   newproperty(:source) do

--- a/lib/puppet/type/selinux_login.rb
+++ b/lib/puppet/type/selinux_login.rb
@@ -19,6 +19,15 @@ Puppet::Type.newtype(:selinux_login) do
     isrequired
   end
 
+  newproperty(:source) do
+    desc 'Source of the login configuration - either policy or local'
+    newvalues(:policy, :local)
+
+    validate do |_value|
+      raise ArgumentError, ':source is a read-only property'
+    end
+  end
+
   autorequire(:package) do
     %w[
       policycoreutils

--- a/lib/puppet_x/voxpupuli/selinux/semanage_ports.py
+++ b/lib/puppet_x/voxpupuli/selinux/semanage_ports.py
@@ -32,11 +32,15 @@ def print_port(kind, port):
 
 # Always list local ports afterwards so that the provider works correctly
 retval, ports = semanage.semanage_port_list(handle)
+if retval < 0:
+    raise ValueError("Could not list port config")
 
 for port in ports:
     print_port('policy', port)
 
 retval, ports = semanage.semanage_port_list_local(handle)
+if retval < 0:
+    raise ValueError("Could not list local port config")
 
 for port in ports:
     print_port('local', port)

--- a/lib/puppet_x/voxpupuli/selinux/semanage_users.py
+++ b/lib/puppet_x/voxpupuli/selinux/semanage_users.py
@@ -1,5 +1,5 @@
-# This script uses libsemanage directly to access the ports list
-# it is *much* faster than semanage port -l
+# This script uses libsemanage directly to access the logins list
+# This is *much* faster than semanage login -l
 
 # will work with python 2.6+
 from __future__ import print_function
@@ -7,10 +7,10 @@ from sys import exit
 try:
   import semanage
 except ImportError:
-  # The semanage python library does not exist, so let's assume SELinux is disabled...
-  # In this case, the correct response is to return no ports when puppet does a
-  # prefetch, to avoid an error. We depend on the semanage binary anyway, which
-  # is uses the library
+  # The semanage python library does not exist, so let's assume SELinux is
+  # disabled. In this case, the correct response is to return no logins when
+  # puppet does a prefetch, to avoid an error. We depend on the semanage binary
+  # anyway, which uses the library
   exit(0)
 
 
@@ -21,16 +21,26 @@ if semanage.semanage_is_managed(handle) < 0:
 if semanage.semanage_connect(handle) < 0:
     exit(1)
 
-def print_seuser(seuser):
+def print_seuser(kind, seuser):
     seuser_login = semanage.semanage_seuser_get_name(seuser)
     selinux_user = semanage.semanage_seuser_get_sename(seuser)
-    print("{} {}".format(seuser_login, selinux_user))
+    print("{} {} {}".format(kind, seuser_login, selinux_user))
 
 
+# Always list local config afterwards so that the provider works correctly
 (status, seusers) = semanage.semanage_seuser_list(handle)
+if status < 0:
+    raise ValueError("Could not list user config")
 
 for seuser in seusers:
-    print_seuser(seuser)
+    print_seuser('policy', seuser)
+
+(status, seusers) = semanage.semanage_seuser_list_local(handle)
+if status < 0:
+    raise ValueError("Could not list local user config")
+
+for seuser in seusers:
+    print_seuser('local', seuser)
 
 
 semanage.semanage_disconnect(handle)

--- a/manifests/login.pp
+++ b/manifests/login.pp
@@ -35,7 +35,7 @@ define selinux::login (
 
   # Do nothing unless SELinux is enabled
   if $facts['os']['selinux']['enabled'] {
-    selinux_login { "${selinux_login_name}_${selinux_user}":
+    selinux_login { $selinux_login_name:
       ensure             => $ensure,
       selinux_login_name => $selinux_login_name,
       selinux_user       => $selinux_user,


### PR DESCRIPTION
#### Pull Request (PR) description
This PR provides a small number of fixes for the `selinux::login` defined resource, including:
 - A reference to Nil in the provider.prefetch method
 - Changing the resource's arguments correctly shows up as changing the mapping, not creating a new one and deleting the previous version
 - Additional error handling in the helper script

#### This Pull Request (PR) fixes the following issues
n/a
