### PR TITLE
README: refer to metadata.json in the Requirements section

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ This class manages SELinux.
 
 ## Requirements
 
-* Puppet 5 or later
+* See `metadata.json`
 
 ## Module Description
 


### PR DESCRIPTION
The "Puppet 5 or later" requirement went obsolete with commit 69988c1723191f48f858a8726efdd337a8dbe0de. Let's refer to the metadata rather than try to keep this section of the README up-to-date.