### PR TITLE
selinux_build_module_simple.sh: improve quoting

### DIFF
--- a/files/selinux_build_module_simple.sh
+++ b/files/selinux_build_module_simple.sh
@@ -4,13 +4,13 @@ module_dir="$2"
 
 set -e
 
-cd $module_dir
-test -d tmp || mkdir tmp
+cd "$module_dir"
+mkdir -p tmp
 
-checkmodule -M -m -o tmp/${module_name}.mod ${module_name}.te
-package_args="-o ${module_name}.pp -m tmp/${module_name}.mod"
+checkmodule -M -m -o "tmp/${module_name}.mod" "${module_name}.te"
+
 if [ -s "${module_name}.fc" ]; then
-    package_args="${package_args} --fc ${module_name}.fc"
+    semodule_package -o "${module_name}.pp" -m "tmp/${module_name}.mod" --fc "${module_name}.fc"
+else
+    semodule_package -o "${module_name}.pp" -m "tmp/${module_name}.mod"
 fi
-
-semodule_package ${package_args}

--- a/manifests/module.pp
+++ b/manifests/module.pp
@@ -136,7 +136,7 @@ define selinux::module (
       exec { "build-module-${title}":
         path    => '/bin:/usr/bin',
         cwd     => $module_dir,
-        command => "${build_command} || (rm -f ${module_file}.pp ${module_file}.loaded && exit 1)",
+        command => "${build_command} || (rm -f '${module_file}.pp' '${module_file}.loaded' && exit 1)",
         creates => "${module_file}.pp",
         notify  => Exec["install-module-${title}"],
       }
@@ -168,7 +168,7 @@ define selinux::module (
       exec { "install-module-${title}":
         path    => '/sbin:/usr/sbin:/bin:/usr/bin',
         cwd     => $module_dir,
-        command => "semodule -i ${module_file}.pp && touch ${module_file}.loaded",
+        command => "semodule -i '${module_file}.pp' && touch '${module_file}.loaded'",
         creates => "${module_file}.loaded",
         before  => Selmodule[$title],
       }

--- a/spec/defines/selinux_module_spec.rb
+++ b/spec/defines/selinux_module_spec.rb
@@ -46,8 +46,8 @@ describe 'selinux::module' do
           it { is_expected.to contain_file("#{workdir}/mymodule.fc").with(source: nil, content: '') }
           it { is_expected.to contain_file("#{workdir}/mymodule.if").with(source: nil, content: '') }
           it { is_expected.to contain_exec('clean-module-mymodule').with(command: "rm -f '#{module_basepath}.pp' '#{module_basepath}.loaded'", cwd: workdir) }
-          it { is_expected.to contain_exec('build-module-mymodule').with(command: "make -f /usr/share/selinux/devel/Makefile mymodule.pp || (rm -f #{module_basepath}.pp #{module_basepath}.loaded && exit 1)", creates: "#{module_basepath}.pp") }
-          it { is_expected.to contain_exec('install-module-mymodule').with(command: "semodule -i #{module_basepath}.pp && touch #{module_basepath}.loaded", cwd: workdir, creates: "#{module_basepath}.loaded") }
+          it { is_expected.to contain_exec('build-module-mymodule').with(command: "make -f /usr/share/selinux/devel/Makefile mymodule.pp || (rm -f '#{module_basepath}.pp' '#{module_basepath}.loaded' && exit 1)", creates: "#{module_basepath}.pp") }
+          it { is_expected.to contain_exec('install-module-mymodule').with(command: "semodule -i '#{module_basepath}.pp' && touch '#{module_basepath}.loaded'", cwd: workdir, creates: "#{module_basepath}.loaded") }
           it { is_expected.to contain_selmodule('mymodule').with_ensure('present', selmodulepath: workdir) }
         end
 
@@ -65,8 +65,8 @@ describe 'selinux::module' do
           it { is_expected.to contain_file("#{workdir}/mymodule.fc").that_notifies('Exec[clean-module-mymodule]') }
           it { is_expected.to contain_file("#{workdir}/mymodule.if").with(source: nil, content: '') }
           it { is_expected.to contain_exec('clean-module-mymodule').with(command: "rm -f '#{module_basepath}.pp' '#{module_basepath}.loaded'", cwd: workdir) }
-          it { is_expected.to contain_exec('build-module-mymodule').with(command: "make -f /usr/share/selinux/devel/Makefile mymodule.pp || (rm -f #{module_basepath}.pp #{module_basepath}.loaded && exit 1)", creates: "#{module_basepath}.pp") }
-          it { is_expected.to contain_exec('install-module-mymodule').with(command: "semodule -i #{module_basepath}.pp && touch #{module_basepath}.loaded", cwd: workdir, creates: "#{module_basepath}.loaded") }
+          it { is_expected.to contain_exec('build-module-mymodule').with(command: "make -f /usr/share/selinux/devel/Makefile mymodule.pp || (rm -f '#{module_basepath}.pp' '#{module_basepath}.loaded' && exit 1)", creates: "#{module_basepath}.pp") }
+          it { is_expected.to contain_exec('install-module-mymodule').with(command: "semodule -i '#{module_basepath}.pp' && touch '#{module_basepath}.loaded'", cwd: workdir, creates: "#{module_basepath}.loaded") }
           it { is_expected.to contain_selmodule('mymodule').with_ensure('present', selmodulepath: workdir) }
         end
 
@@ -85,8 +85,8 @@ describe 'selinux::module' do
           it { is_expected.to contain_file("#{workdir}/mymodule.if").that_notifies('Exec[clean-module-mymodule]') }
           it { is_expected.to contain_file("#{workdir}/mymodule.fc").that_notifies('Exec[clean-module-mymodule]') }
           it { is_expected.to contain_exec('clean-module-mymodule').with(command: "rm -f '#{module_basepath}.pp' '#{module_basepath}.loaded'", cwd: workdir) }
-          it { is_expected.to contain_exec('build-module-mymodule').with(command: "make -f /usr/share/selinux/devel/Makefile mymodule.pp || (rm -f #{module_basepath}.pp #{module_basepath}.loaded && exit 1)", creates: "#{module_basepath}.pp") }
-          it { is_expected.to contain_exec('install-module-mymodule').with(command: "semodule -i #{module_basepath}.pp && touch #{module_basepath}.loaded", cwd: workdir, creates: "#{module_basepath}.loaded") }
+          it { is_expected.to contain_exec('build-module-mymodule').with(command: "make -f /usr/share/selinux/devel/Makefile mymodule.pp || (rm -f '#{module_basepath}.pp' '#{module_basepath}.loaded' && exit 1)", creates: "#{module_basepath}.pp") }
+          it { is_expected.to contain_exec('install-module-mymodule').with(command: "semodule -i '#{module_basepath}.pp' && touch '#{module_basepath}.loaded'", cwd: workdir, creates: "#{module_basepath}.loaded") }
           it { is_expected.to contain_selmodule('mymodule').with_ensure('present', selmodulepath: workdir) }
         end
 
@@ -105,8 +105,8 @@ describe 'selinux::module' do
           it { is_expected.to contain_file("#{workdir}/mymodule.if").with(source: nil, content: 'interface(puppet_test)').that_notifies('Exec[clean-module-mymodule]') }
           it { is_expected.to contain_file("#{workdir}/mymodule.fc").with(source: nil, content: '/bin/sh system_u:object_r:bin_t').that_notifies('Exec[clean-module-mymodule]') }
           it { is_expected.to contain_exec('clean-module-mymodule').with(command: "rm -f '#{module_basepath}.pp' '#{module_basepath}.loaded'", cwd: workdir) }
-          it { is_expected.to contain_exec('build-module-mymodule').with(command: "make -f /usr/share/selinux/devel/Makefile mymodule.pp || (rm -f #{module_basepath}.pp #{module_basepath}.loaded && exit 1)", creates: "#{module_basepath}.pp") }
-          it { is_expected.to contain_exec('install-module-mymodule').with(command: "semodule -i #{module_basepath}.pp && touch #{module_basepath}.loaded", cwd: workdir, creates: "#{module_basepath}.loaded") }
+          it { is_expected.to contain_exec('build-module-mymodule').with(command: "make -f /usr/share/selinux/devel/Makefile mymodule.pp || (rm -f '#{module_basepath}.pp' '#{module_basepath}.loaded' && exit 1)", creates: "#{module_basepath}.pp") }
+          it { is_expected.to contain_exec('install-module-mymodule').with(command: "semodule -i '#{module_basepath}.pp' && touch '#{module_basepath}.loaded'", cwd: workdir, creates: "#{module_basepath}.loaded") }
           it { is_expected.to contain_selmodule('mymodule').with_ensure('present', selmodulepath: workdir) }
         end
 
@@ -124,8 +124,8 @@ describe 'selinux::module' do
           it { is_expected.to contain_file("#{workdir}/mymodule.fc").with(source: nil, content: '') }
           it { is_expected.to contain_file("#{workdir}/mymodule.if").with(source: nil, content: '') }
           it { is_expected.to contain_exec('clean-module-mymodule').with(command: "rm -f '#{module_basepath}.pp' '#{module_basepath}.loaded'", cwd: workdir) }
-          it { is_expected.to contain_exec('build-module-mymodule').with(command: "/var/lib/puppet/puppet-selinux/bin/selinux_build_module_simple.sh mymodule #{workdir} || (rm -f #{module_basepath}.pp #{module_basepath}.loaded && exit 1)", creates: "#{module_basepath}.pp") }
-          it { is_expected.to contain_exec('install-module-mymodule').with(command: "semodule -i #{module_basepath}.pp && touch #{module_basepath}.loaded", cwd: workdir, creates: "#{module_basepath}.loaded") }
+          it { is_expected.to contain_exec('build-module-mymodule').with(command: "/var/lib/puppet/puppet-selinux/bin/selinux_build_module_simple.sh mymodule #{workdir} || (rm -f '#{module_basepath}.pp' '#{module_basepath}.loaded' && exit 1)", creates: "#{module_basepath}.pp") }
+          it { is_expected.to contain_exec('install-module-mymodule').with(command: "semodule -i '#{module_basepath}.pp' && touch '#{module_basepath}.loaded'", cwd: workdir, creates: "#{module_basepath}.loaded") }
           it { is_expected.to contain_selmodule('mymodule').with_ensure('present', selmodulepath: workdir) }
         end
 
@@ -142,8 +142,8 @@ describe 'selinux::module' do
           it { is_expected.to contain_file("#{workdir}/mymodule.fc").with(source: nil, content: '') }
           it { is_expected.to contain_file("#{workdir}/mymodule.if").with(source: nil, content: '') }
           it { is_expected.to contain_exec('clean-module-mymodule').with(command: "rm -f '#{module_basepath}.pp' '#{module_basepath}.loaded'", cwd: workdir) }
-          it { is_expected.to contain_exec('build-module-mymodule').with(command: "/var/lib/puppet/puppet-selinux/bin/selinux_build_module_simple.sh mymodule #{workdir} || (rm -f #{module_basepath}.pp #{module_basepath}.loaded && exit 1)", creates: "#{module_basepath}.pp") }
-          it { is_expected.to contain_exec('install-module-mymodule').with(command: "semodule -i #{module_basepath}.pp && touch #{module_basepath}.loaded", cwd: workdir, creates: "#{module_basepath}.loaded") }
+          it { is_expected.to contain_exec('build-module-mymodule').with(command: "/var/lib/puppet/puppet-selinux/bin/selinux_build_module_simple.sh mymodule #{workdir} || (rm -f '#{module_basepath}.pp' '#{module_basepath}.loaded' && exit 1)", creates: "#{module_basepath}.pp") }
+          it { is_expected.to contain_exec('install-module-mymodule').with(command: "semodule -i '#{module_basepath}.pp' && touch '#{module_basepath}.loaded'", cwd: workdir, creates: "#{module_basepath}.loaded") }
           it { is_expected.to contain_selmodule('mymodule').with_ensure('present', selmodulepath: workdir) }
         end
 
@@ -170,7 +170,7 @@ describe 'selinux::module' do
           it { is_expected.to contain_file(workdir) }
           it { is_expected.to contain_file("#{workdir}/mymodule.pp").that_notifies('Exec[clean-module-mymodule]') }
           it { is_expected.to contain_exec('clean-module-mymodule').with(command: "rm -f '#{module_basepath}.loaded'", cwd: workdir) }
-          it { is_expected.to contain_exec('install-module-mymodule').with(command: "semodule -i #{module_basepath}.pp && touch #{module_basepath}.loaded", cwd: workdir, creates: "#{module_basepath}.loaded") }
+          it { is_expected.to contain_exec('install-module-mymodule').with(command: "semodule -i '#{module_basepath}.pp' && touch '#{module_basepath}.loaded'", cwd: workdir, creates: "#{module_basepath}.loaded") }
           it { is_expected.to contain_selmodule('mymodule').with_ensure('present', selmodulepath: workdir) }
         end
 


### PR DESCRIPTION
If module_name or module_dir had a space, this script would fail.

Also avoid existence test for the tmp dir and use mkdir -p instead.