### PR TITLE
Fix `selinux_login` provider typo and title mismatch

### DIFF
--- a/lib/puppet/provider/selinux_login/semanage.rb
+++ b/lib/puppet/provider/selinux_login/semanage.rb
@@ -109,7 +109,7 @@ Puppet::Type.type(:selinux_login).provide(:semanage) do
         resource.provider = provider
         resource[:ensure] = :present if provider.source == :policy
       else
-        resources.each_values do |res|
+        resources.each_value do |res|
           next unless res[:selinux_user] == provider.selinux_user && res[:selinux_login_name] == provider.selinux_login_name
 
           warning("Selinux_login['#{res[:name]}']: title does not match its login ('#{provider.name}' != '#{provider.selinux_login_name}')")

--- a/lib/puppet/provider/selinux_login/semanage.rb
+++ b/lib/puppet/provider/selinux_login/semanage.rb
@@ -67,7 +67,7 @@ Puppet::Type.type(:selinux_login).provide(:semanage) do
       # local %cn_cegbu_aconex_fr-dev-platform-priv unconfined_u
       source_str, selinux_login_name, selinux_user = split
 
-      key = "#{selinux_login_name}_#{selinux_user}"
+      key = selinux_login_name
       source =
         case source_str
         when 'policy' then :policy


### PR DESCRIPTION
#### Pull Request (PR) description

`selinux::login` fails to run due to two bugs in the `selinux_login` provider.

##### Typo
Is presumably a typo in `each_values`

##### Inconsistency in the titles between resources and instances

This logic used to use the title of `#{selinux_login_name}_#{selinux_user}` but has been changed to just use the `selinux_login_name` (340c17e345d09d64289d35d4b1a18d533dfd3b40).

When we check `resource = resources[provider.name]` the inconsistency means if the resource already exists we get the following error.

```
Warning: Puppet::Type::Selinux_login::ProviderSemanage: Selinux_login['user']: title does not match its login ('user_staff_u' != 'user')
Error: Could not prefetch selinux_login provider 'semanage': undefined method `provider=' for nil:NilClass
```