### PR TITLE
Optimize fcontext parsing methods

### DIFF
--- a/lib/puppet/provider/selinux_fcontext/semanage.rb
+++ b/lib/puppet/provider/selinux_fcontext/semanage.rb
@@ -27,10 +27,9 @@ Puppet::Type.type(:selinux_fcontext).provide(:semanage) do
   end
 
   def self.parse_fcontext_lines(lines)
-    ret = []
-    lines.each do |line|
+    lines.filter_map do |line|
       next if line.strip.empty?
-      next if line =~ %r{^#}
+      next if line.start_with?('#')
 
       split = line.split(%r{\s+})
       if split.length == 2
@@ -45,16 +44,16 @@ Puppet::Type.type(:selinux_fcontext).provide(:semanage) do
         user = range = role = nil
       end
       ft = file_type_map(file_type)
-      ret.push(new(ensure: :present,
-                   name: "#{path_spec}_#{ft}",
-                   pathspec: path_spec,
-                   seltype: type,
-                   seluser: user,
-                   selrole: role,
-                   selrange: range,
-                   file_type: ft))
+
+      new(ensure: :present,
+          name: "#{path_spec}_#{ft}",
+          pathspec: path_spec,
+          seltype: type,
+          seluser: user,
+          selrole: role,
+          selrange: range,
+          file_type: ft)
     end
-    ret
   end
 
   def self.parse_fcontext_file(path)

--- a/lib/puppet/provider/selinux_fcontext_equivalence/semanage.rb
+++ b/lib/puppet/provider/selinux_fcontext_equivalence/semanage.rb
@@ -11,17 +11,16 @@ Puppet::Type.type(:selinux_fcontext_equivalence).provide(:semanage) do
   mk_resource_methods
 
   def self.parse_fcontext_subs_lines(lines)
-    ret = []
-    lines.each do |line|
+    lines.filter_map do |line|
       next if line.strip.empty?
-      next if line =~ %r{^#}
+      next if line.start_with?('#')
 
       source, target = line.split(%r{\s+})
-      ret.push(new(ensure: :present,
-                   name: source,
-                   target: target))
+
+      new(ensure: :present,
+          name: source,
+          target: target)
     end
-    ret
   end
 
   def self.instances


### PR DESCRIPTION
This uses filter_map (introduced in Ruby 2.7) to avoid constructing an array by pushing values. It also uses start_with to avoid a regex lookup.

Untested now, and since there aren't any acceptance tests running now I'm a bit hesitant on merging this.