### PR TITLE
selinux_login: Make semanage spec independent of host SELinux state

### DIFF
--- a/spec/unit/provider/selinux_login/semanage_spec.rb
+++ b/spec/unit/provider/selinux_login/semanage_spec.rb
@@ -80,6 +80,15 @@ RESOURCE_EXAMPLE.delete(:source)
 LOGIN_TYPE = Puppet::Type.type(:selinux_login)
 
 describe LOGIN_TYPE.provider(:semanage) do
+  # The provider is confined to `os.selinux.enabled: true`. On a host where
+  # SELinux is enabled, the provider is "suitable" and Puppet::Type#provider
+  # falls back to instantiating it for resources that prefetch did not
+  # explicitly attach. That makes the `provider).to be_nil` assertion below
+  # pass on Debian-based CI containers but fail on a SELinux host (e.g.
+  # Fedora). Force unsuitability so the test reflects what prefetch did,
+  # not what the host happens to look like.
+  before { allow(described_class).to receive(:suitable?).and_return(false) }
+
   on_supported_os.each_key do |os|
     context "on #{os}" do
       context 'with some local login definitions' do


### PR DESCRIPTION
#### Pull Request (PR) description
The "prefetch does not find a provider for nonexistant user" example relies on `Puppet::Type#provider` returning `nil` when prefetch did not attach a provider. That only happens when the `:semanage` provider is unsuitable on the host running the tests, because the provider is confined to `os.selinux.enabled: true` and `Puppet::Type#provider` falls back to instantiating the suitable default when no provider is set.

The Debian-based CI containers don't have SELinux, so the test passes upstream. On a host with SELinux on (Fedora, RHEL, etc.) the fallback returns a fresh `ProviderSemanage` and the assertion fails.

Stub `suitable?` to `false` at the describe level so the test reflects what prefetch actually did, regardless of host state.

#### This Pull Request (PR) fixes the following issues
N/A